### PR TITLE
Document Sentinel script execution (fixes #468)

### DIFF
--- a/topics/sentinel.md
+++ b/topics/sentinel.md
@@ -452,6 +452,56 @@ configuring only the `masterauth` directive for this slave, without
 the `requirepass` directive, so that data will be readable by unauthenticated
 clients.
 
+Sentinel scripts execution
+===
+
+`sentinel notification-script` and `sentinel reconfig-script` are used in order
+to configure scripts that are called to notify the system administrator
+or to reconfigure clients after a failover. The scripts are executed
+with the following rules for error handling:
+
+* If script exits with "1" the execution is retried later (up to a maximum number of times currently set to 10).
+* If script exits with "2" (or an higher value) the script execution is not retried.
+* If script terminates because it receives a signal the behavior is the same as exit code 1.
+* A script has a maximum running time of 60 seconds. After this limit is reached the script is terminated with a SIGKILL and the execution retried.
+
+Notification Script
+---
+
+Usage: `sentinel notification-script <master-name> <script-path>`
+
+Call the specified notification script for any sentinel event that is generated in the WARNING level (for instance `-sdown`, `-odown`, and so forth). This script should notify the system administrator via email, SMS, or any other messaging system, that there is something wrong with the monitored Redis systems.
+
+The script is called with just two arguments: the first is the event type and the second the event description.
+
+The script must exist and be executable in order for sentinel to start if this option is provided.
+
+Example:
+
+    sentinel notification-script mymaster /var/redis/notify.sh
+
+Clients Reconfiguration Script
+---
+
+Usage: `sentinel client-reconfig-script <master-name> <script-path>`
+
+When the master changed because of a failover a script can be called in order to perform application-specific tasks to notify the clients that the configuration has changed and the master is at a different address.
+
+The following arguments are passed to the script:
+
+    <master-name> <role> <state> <from-ip> <from-port> <to-ip> <to-port>
+
+* `<state>` is currently always `failover`
+* `<role>` is either `leader` or `observer`
+
+The arguments `from-ip`, `from-port`, `to-ip`, `to-port` are used to communicate the old address of the master and the new address of the elected slave (now a master).
+
+This script should be resistant to multiple invocations.
+
+Example:
+
+    sentinel client-reconfig-script mymaster /var/redis/reconfig.sh
+
 Sentinel API
 ===
 


### PR DESCRIPTION
Fix for #468: adds documentation for Sentinel script execution (trivial copy of the sentinel.conf file, should be proof-read for documentation worthiness)
