### PR TITLE
Update time complexity of EXISTS, LPUSH, RPUSH, SPOP

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1257,7 +1257,7 @@
   },
   "EXISTS": {
     "summary": "Determine if a key exists",
-    "complexity": "O(1)",
+    "complexity": "O(N) where N is the number of keys to check.",
     "arguments": [
       {
         "name": "key",
@@ -3793,7 +3793,7 @@
   },
   "SPOP": {
     "summary": "Remove and return one or multiple random members from a set",
-    "complexity": "O(1)",
+    "complexity": "Without the count argument O(1), otherwise O(N) where N is the value of the passed count.",
     "arguments": [
       {
         "name": "key",


### PR DESCRIPTION
Commands that support multiple arguments and have a time complexity of O(1) for a single argument, such as, DEL, HDEL, HMGET, HMSET, MGET, MSET, MSETNX, SADD, and SREM, have a time complexity of O(N) where N is the number of arguments.

I believe that the time complexities of EXISTS, LPUSH, and RPUSH were not updated when support for multiple arguments was added to each command. The respective lines of code that I think support this change are: [EXISTS](https://github.com/antirez/redis/blob/33769f840cd53f03caf8f4b886a7c95182492027/src/db.c#L327), and [LPUSH & RPUSH](https://github.com/antirez/redis/blob/33769f840cd53f03caf8f4b886a7c95182492027/src/t_list.c#L206).

SPOP is more complex but very similar to SRANDMEMBER, so I believe that the time complexity of [SRANDMEMBER](https://github.com/antirez/redis-doc/blob/11bb96b1f4aba4c1f84b0d7f872b7572fb9eb2e4/commands.json#L2306) fits SPOP's time complexity.

WDYT?
