### PR TITLE
Update RedisModule_GetThreadSafeContext section

### DIFF
--- a/topics/modules-api-ref.md
+++ b/topics/modules-api-ref.md
@@ -1509,9 +1509,9 @@ detached by a specific client.
 
 To call non-reply APIs, the thread safe context must be prepared with:
 
-    RedisModule_ThreadSafeCallStart(ctx);
+    RedisModule_ThreadSafeContextLock(ctx);
     ... make your call here ...
-    RedisModule_ThreadSafeCallStop(ctx);
+    RedisModule_ThreadSafeContextUnlock(ctx);
 
 This is not needed when using ``RedisModule_Reply`*` functions, assuming
 that a blocked client was used when the context was created, otherwise


### PR DESCRIPTION
Rename RedisModule_ThreadSafeCallStart and RedisModule_ThreadSafeCallStop to RedisModule_ThreadSafeContextLock and RedisModule_ThreadSafeContextUnlock