### PR TITLE
Rate Limiter Pattern Improvements (new)

### DIFF
--- a/commands/incr.md
+++ b/commands/incr.md
@@ -120,9 +120,8 @@ value greater than 10, otherwise it will expire and start again from 0.
 If for some reason the client performs the `INCR` command but does not perform
 the `EXPIRE` the key will be leaked until we'll see the same IP address again.
 
-One solution to this is using a default TTL for your redis keys. Another 
-solution is converting the `INCR` with optional `EXPIRE` into a Lua script that 
-is sent using the `EVAL` command (only available since Redis version 2.6).
+This can be fixed by turning the `INCR` with optional `EXPIRE` into a Lua script,
+sent using the `EVAL` command (only available since Redis version 2.6).
 
 ```
 local value

--- a/commands/incr.md
+++ b/commands/incr.md
@@ -92,17 +92,10 @@ connection with redis, we will never see keys created without an expiry.
 Also note how we make checks after incrementing, to ensure this thread is seeing
 a unique value of the key.
 
-**Caution**: If there is a significant amount of time that passes between getting
-the current unix time and redis executing the multi block (major network
-latency for example), the rate limit key for that second could expire before
-we increment. This could allow >10 api calls in a given time interval. This
-is why we use an expiry of 10 seconds, and feel free to increase this value if
-needed in practice.
-
 ## Pattern: Rate limiter 2
 
 An alternative implementation uses a single counter, but is a bit more complex
-to get it right without race conditions.
+to get it right considering exceptional behavior.
 We'll examine different variants.
 
 ```
@@ -144,8 +137,6 @@ complex and uses more advanced features, but has the advantage of remembering th
 IP addresses of the clients currently performing an API call. This could be
 useful depending on the application.
 
-**This implementation is not safe for concurrent usage**
-
 ```
 FUNCTION LIMIT_API_CALL(ip)
 current = LLEN(ip)
@@ -163,6 +154,8 @@ ELSE
     PERFORM_API_CALL()
 END
 ```
+
+**The above code is not safe for concurrent usage**
 
 The `RPUSHX` command only pushes the element if the key already exists.
 


### PR DESCRIPTION
# Why
The redis-docs are supposed to be designed for beginners learning about how to use redis. However, the incr docs can lead these new developers into implementing non-thread-safe rate limiters in their modern web applications.

Here is an explanation of why the current code fails, and how the new code improves in concurrency.
![concurrency_explanation](https://user-images.githubusercontent.com/9659853/70394425-16cbe600-19c3-11ea-8d23-034bec7ef4bd.png)

# What
Made very minor changes to two of the three provided examples to support concurrent rate limiting.
Fixed minor grammar/spelling mistakes throughout the section.
Elaborated on **why** the examples are written the way they are (concurrency, exceptional behavior outcomes, etc.) and what the short-comings of each example are.

I believe these changes are simpler, easier to follow, and more effective than the previous PRs opened to address this problem. (#893 and #782).
Please consider my changes, and let me know if anything I wrote needs elaboration.
