### PR TITLE
Moves some commands to a new 'bit' category

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -57,7 +57,7 @@
       }
     ],
     "since": "2.6.0",
-    "group": "bit"
+    "group": "bitmap"
   },
   "BITFIELD": {
     "summary": "Perform arbitrary bitfield integer operations on strings",
@@ -119,7 +119,7 @@
       }
     ],
     "since": "3.2.0",
-    "group": "bit"
+    "group": "bitmap"
   },
   "BITOP": {
     "summary": "Perform bitwise operations between strings",
@@ -140,7 +140,7 @@
       }
     ],
     "since": "2.6.0",
-    "group": "bit"
+    "group": "bitmap"
   },
   "BITPOS": {
     "summary": "Find first bit set or clear in a string",
@@ -166,7 +166,7 @@
       }
     ],
     "since": "2.8.7",
-    "group": "bit"
+    "group": "bitmap"
   },
   "BLPOP": {
     "summary": "Remove and get the first element in a list, or block until one is available",
@@ -1220,7 +1220,7 @@
       }
     ],
     "since": "2.2.0",
-    "group": "bit"
+    "group": "bitmap"
   },
   "GETRANGE": {
     "summary": "Get a substring of the string stored at a key",
@@ -2548,7 +2548,7 @@
       }
     ],
     "since": "2.2.0",
-    "group": "bit"
+    "group": "bitmap"
   },
   "SETEX": {
     "summary": "Set the value and expiration of a key",

--- a/commands.json
+++ b/commands.json
@@ -57,7 +57,7 @@
       }
     ],
     "since": "2.6.0",
-    "group": "string"
+    "group": "bit"
   },
   "BITFIELD": {
     "summary": "Perform arbitrary bitfield integer operations on strings",
@@ -119,7 +119,7 @@
       }
     ],
     "since": "3.2.0",
-    "group": "string"
+    "group": "bit"
   },
   "BITOP": {
     "summary": "Perform bitwise operations between strings",
@@ -140,7 +140,7 @@
       }
     ],
     "since": "2.6.0",
-    "group": "string"
+    "group": "bit"
   },
   "BITPOS": {
     "summary": "Find first bit set or clear in a string",
@@ -166,7 +166,7 @@
       }
     ],
     "since": "2.8.7",
-    "group": "string"
+    "group": "bit"
   },
   "BLPOP": {
     "summary": "Remove and get the first element in a list, or block until one is available",
@@ -1220,7 +1220,7 @@
       }
     ],
     "since": "2.2.0",
-    "group": "string"
+    "group": "bit"
   },
   "GETRANGE": {
     "summary": "Get a substring of the string stored at a key",
@@ -2548,7 +2548,7 @@
       }
     ],
     "since": "2.2.0",
-    "group": "string"
+    "group": "bit"
   },
   "SETEX": {
     "summary": "Set the value and expiration of a key",


### PR DESCRIPTION
This moves the 6 bit-related commands from the 'string' to a new
category. The motivation is giving more exposure for these lesser-
known capabilities.

@antirez - your thoughts?

TODO:
  [ ] Add Bit group in redis-io/lib/reference.rb