### PR TITLE
add Redis-ImageScout to modules.json

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -297,7 +297,7 @@
     "authors": [
       "starkdg"
      ],
-     "stars": 13
+     "stars": 14
     },
   {
     "name": "redismodule-ratelimit",
@@ -338,5 +338,15 @@
       "zhao-lang"
     ],
     "stars":0
-  }	
+  }
+  {
+    "name": "Redis-ImageScout",
+	"license":"pHash Redis Source Available License",
+	"repository": "https://github.com/starkdg/Redis-ImageScout.git",
+	"description": "Redis module for Indexing pHash Image fingerprints",
+	"authors": [
+		"starkdg"
+		],
+	"stars":2
+  }
 ]


### PR DESCRIPTION
Redis-ImageScout is a new Redis Module that introduces a a native datatype for indexing image phash fingerprints. Able to find near-duplicate images with moderate level distortion. 