### PR TITLE
Add Runnel to tools.json

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -738,6 +738,12 @@
     "repository": "https://github.com/pbotros/river",
     "description": "A structured streaming framework built atop Redis Streams with built-in support for persistence and indefinitely long streams.",
     "authors": []
+  },
+  {
+    "name": "Runnel",
+    "language": "Python",
+    "repository": "https://github.com/mjwestcott/runnel",
+    "description": "Distributed event processing for Python based on Redis Streams",
+    "authors": ["mjwestcott"]
   }
-
 ]


### PR DESCRIPTION
Itamar Haber invited me to add [Runnel](https://github.com/mjwestcott/runnel), a stream processing framework for Python that adds Kafka-like semantics to the streams data structure. I wrote about this topic in a blog post [comparing Redis streams and Kafka](https://mattwestcott.co.uk/blog/redis-streams-vs-kafka). Thanks!