### PR TITLE
Adds AUTH2 form to `MIGRATE`

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2150,6 +2150,12 @@
         "optional": true
       },
       {
+        "command": "AUTH2",
+        "name": "username password",
+        "type": "string",
+        "optional": true
+      },
+      {
         "name": "key",
         "command": "KEYS",
         "type": "key",

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -66,10 +66,12 @@ just a single key exists.
 * `AUTH` -- Authenticate with the given password to the remote instance.
 * `AUTH2` -- Authenticate with the given username and password pair (Redis 6 or greater ACL auth style).
 
-`COPY` and `REPLACE` are available only in 3.0 and above.
-`KEYS` is available starting with Redis 3.0.6.
-`AUTH` is available starting with Redis 4.0.7.
-`AUTH2` is available starting with Redis 6.0.0.
+@history
+
+* `>= 3.0.0`: Added the `COPY` and `REPLACE` options.
+* `>= 3.0.6`: Added the `KEYS` option.
+* `>= 4.0.7`: Added the `AUTH` option.
+* `>= 6.0.0`: Added the `AUTH2` option.
 
 @return
 


### PR DESCRIPTION
Regrettably, the current syntax markup doesn't allow for "one out of these subcommands" so that's the best we can do.

After:
![image](https://user-images.githubusercontent.com/6059516/93090345-4e2f9780-f6a5-11ea-9aec-c15610803bef.png)

Also, formalizes the command's history.