### PR TITLE
Adds ACL `AUTH` form syntax

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -137,7 +137,12 @@
     "summary": "Authenticate to the server",
     "arguments": [
       {
-        "name": "password|username password",
+        "name": "username",
+        "type": "string",
+        "optional": true
+      },
+      {
+        "name": "password",
         "type": "string"
       }
     ],

--- a/commands.json
+++ b/commands.json
@@ -137,7 +137,7 @@
     "summary": "Authenticate to the server",
     "arguments": [
       {
-        "name": "password",
+        "name": "password|username password",
         "type": "string"
       }
     ],

--- a/commands/auth.md
+++ b/commands/auth.md
@@ -24,6 +24,10 @@ defined in the ACL list (see `ACL SETUSER`) and the official [ACL guide](/topics
 
 When ACLs are used, the single argument form of the command, where only the password is specified, assumes that the implicit username is "default".
 
+@history
+
+* `>= 6.0.0`: Added ACL style (username and password).
+
 ## Security notice
 
 Because of the high performance nature of Redis, it is possible to try


### PR DESCRIPTION
After: 
![image](https://user-images.githubusercontent.com/6059516/93096498-247a6e80-f6ad-11ea-9463-bf927f5d560b.png)

