### PR TITLE
Update clients.json for Swift language

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1416,7 +1416,7 @@
     "repository": "https://github.com/ronp001/SwiftRedis",
     "description": "Basic async client for Redis in Swift (iOS)",
     "authors": ["ronp001"],
-    "active": true
+    "active": false
   },
 
  {
@@ -1425,7 +1425,7 @@
     "repository": "https://github.com/Zewo/Redis",
     "description": "Redis client for Swift. OpenSwift C7 Compliant, OS X and Linux compatible.",
     "authors": ["rabc"],
-    "active": true
+    "active": false
   },
 
   {
@@ -1434,7 +1434,7 @@
     "repository": "https://github.com/czechboy0/Redbird",
     "description": "Pure-Swift implementation of a Redis client from the original protocol spec (OS X + Linux compatible)",
     "authors": ["czechboy0"],
-    "active": true
+    "active": false
   },
 
   {
@@ -1455,6 +1455,17 @@
     "active": true
   },
 
+  {
+    "name": "RediStack",
+    "language": "Swift",
+    "repository": "https://gitlab.com/Mordil/RediStack",
+    "description": "Non-blocking, event-driven Swift client for Redis built with SwiftNIO for all official Swift deployment environments.",
+    "authors": ["mordil"],
+    "active": true,
+    "recommended": true,
+    "url": "https://docs.redistack.info"
+  },
+  
   {
     "name": "Rackdis",
     "language": "Racket",


### PR DESCRIPTION
Also marks any Swift client that hasn't received an update in over two years as inactive.

The justification for **RediStack** being the recommended client library is due to being accepted by the [Server-side Swift Working Group](https://github.com/swift-server/sswg/blob/main/proposals/0004-nio-redis.md)