### PR TITLE
Fixed an awk regexp escape sequence warning in the makefile.

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ $(TEXT_FILES): tmp/%.txt: %.md
 
 $(SPELL_FILES): %.spell: %.txt tmp/dict
 	aspell -a --extra-dicts=./tmp/dict 2>/dev/null < $< | \
-		awk -v FILE=$(patsubst tmp/%.spell,%.md,$@) '/^\&/ { print FILE, $$2 }' | \
+		awk -v FILE=$(patsubst tmp/%.spell,%.md,$@) '/^&/ { print FILE, $$2 }' | \
 		sort -f | uniq > $@
 
 tmp/commands:


### PR DESCRIPTION
The following warning was printed by awk, when running 'make spell':
awk: cmd. line:1: warning: regexp escape sequence `\&' is not a known
regexp operator

This patch removes the escape in front of the '&' in the awk regexp
and fixes this issue.