### PR TITLE
Added make-check-targets for duplication inside the ./wordlist file.

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,8 +16,31 @@ clients:
 tools:
 	ruby utils/clients.rb tools.json
 
+check_duplicate_wordlist: wordlist
+	@cat wordlist |sort |uniq -c |sort -n \
+		|awk '{ if ($$1 > 1) print "grep -nw "$$2" wordlist"}' \
+		|sh >tmp/duplicates_in_wordlist.txt || true
+	@test -s tmp/duplicates_in_wordlist.txt \
+		&& echo "ERROR: The following word(s) appear more than once in the './wordlist' file:" \
+		&& echo "line:word" \
+		&& echo "---------" \
+		&& cat tmp/duplicates_in_wordlist.txt \
+		|| true
+	@test ! -s tmp/duplicates_in_wordlist.txt
 
-spell: tmp/commands tmp/topics $(SPELL_FILES)
+check_command_wordlist: wordlist tmp/commands.txt check_duplicate_wordlist
+	@cat wordlist tmp/commands.txt |sort |uniq -c |sort -n \
+		|awk '{ if ($$1 > 1) print "grep -nw "$$2" wordlist"}' \
+		|sh >tmp/commands_in_wordlist.txt || true
+	@test -s tmp/commands_in_wordlist.txt \
+		&& echo "ERROR: The following command(s) should be removed from in the './wordlist' file:" \
+		&& echo "line:command" \
+		&& echo "------------" \
+		&& cat tmp/commands_in_wordlist.txt \
+		|| true
+	@test ! -s tmp/commands_in_wordlist.txt
+
+spell: tmp/commands tmp/topics $(SPELL_FILES) check_command_wordlist
 	find tmp -name '*.spell' | xargs cat > tmp/spelling-errors
 	cat tmp/spelling-errors
 	test ! -s tmp/spelling-errors


### PR DESCRIPTION
Spell checking by the 'spell' makefile target is done by using
white-list words originating from commands in the ./commands.json file
as well as words in the ./wordlist file. Two ways of word duplication
in these two files are possible:

   1. A new command gets added to the ./commands.json file, while the
   command already exists in the ./wordlist file.

   2. The same word simply exist twice inside the ./wordlist file.

This patch adds two makefile targets that check for these two cases,
when running 'make spell'.