### PR TITLE
Removed two duplicate words from ./wordlist.

### DIFF
--- a/wordlist
+++ b/wordlist
@@ -8,7 +8,6 @@ BitOp
 Bitfields
 CAS
 CJSON
-CJSON
 CLI
 CP
 CPUs
@@ -94,7 +93,6 @@ PHP
 PINGs
 POSIX
 PRNG
-PSYNC
 PostgreSQL
 Presharding
 RDB


### PR DESCRIPTION
CJSON was a duplicate inside ./wordlist.
PSYNC is a command inside ./commands.json and therefore should not be
listed in the ./wordlist file again.