### PR TITLE
Re-establishes the use of `make spell`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,5 +14,7 @@ jobs:
     - uses: actions/checkout@v2.1.1
     - name: Install dependencies
       run: gem install $(sed -e 's/ -v /:/' .gems)
-    - name: Run tests
+    - name: Sanity parse test
       run: make -s
+    - name: Spelling check
+      run: make spell

--- a/commands/acl-setuser.md
+++ b/commands/acl-setuser.md
@@ -55,7 +55,7 @@ This is a list of all the supported Redis ACL rules:
 * `-@<category>`: Like `+@<category>` but removes all the commands in the category instead of adding them.
 * `nocommands`: alias for `-@all`. Removes all the commands, the user will no longer be able to execute anything.
 * `nopass`: the user is set as a "no password" user. It means that it will be possible to authenticate as such user with any password. By default, the `default` special user is set as "nopass". The `nopass` rule will also reset all the configured passwords for the user.
-* `>password`: Add the specified clear text password as an hashed password in the list of the users passwords. Every user can have many active passwords, so that password rotation will be simpler. The specified password is not stored in cleartext inside the server. Example: `>mypassword`.
+* `>password`: Add the specified clear text password as an hashed password in the list of the users passwords. Every user can have many active passwords, so that password rotation will be simpler. The specified password is not stored as clear text inside the server. Example: `>mypassword`.
 * `#<hashedpassword>`: Add the specified hashed password to the list of user passwords. A Redis hashed password is hashed with SHA256 and translated into a hexadecimal string. Example: `#c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2`.
 * `<password`: Like `>password` but removes the password instead of adding it.
 * `!<hashedpassword>`: Like `#<hashedpassword>` but removes the password instead of adding it.

--- a/commands/client-caching.md
+++ b/commands/client-caching.md
@@ -2,7 +2,7 @@ This command controls the tracking of the keys in the next command executed
 by the connection, when tracking is enabled in `OPTIN` or `OPTOUT` mode.
 Please check the
 [client side caching documentation](/topics/client-side-caching) for
-background informations.
+background information.
 
 When tracking is enabled Redis, using the `CLIENT TRACKING` command, it is
 possible to specify the `OPTIN` or `OPTOUT` options, so that keys

--- a/commands/eval.md
+++ b/commands/eval.md
@@ -602,13 +602,13 @@ was the cause of bugs.
 
 ## Using Lua scripting in RESP3 mode
 
-Starting with Redis version 6, the server supports two differnent protocols.
+Starting with Redis version 6, the server supports two different protocols.
 One is called RESP2, and is the old protocol: all the new connections to
 the server start in this mode. However clients are able to negotiate the
 new protocol using the `HELLO` command: this way the connection is put
 in RESP3 mode. In this mode certain commands, like for instance `HGETALL`,
 reply with a new data type (the Map data type in this specific case). The
-RESP3 protocol is semantically more powerful, however most scripts are ok
+RESP3 protocol is semantically more powerful, however most scripts are OK
 with using just RESP2.
 
 The Lua engine always assumes to run in RESP2 mode when talking with Redis,
@@ -647,7 +647,7 @@ At this point the new conversions are available, specifically:
 
 * Lua boolean -> Redis boolean true or false. **Note that this is a change compared to the RESP2 mode**, where returning true from Lua returned the number 1 to the Redis client, and returning false used to return NULL.
 * Lua table with a single `map` field set to a field-value Lua table -> Redis map reply.
-* Lua table with a single `set` field set to a field-value Lua table -> Redis set reply, the values are discared and can be anything.
+* Lua table with a single `set` field set to a field-value Lua table -> Redis set reply, the values are discarded and can be anything.
 * Lua table with a single `double` field set to a field-value Lua table -> Redis double reply.
 * Lua null -> Redis RESP3 new null reply (protocol `"_\r\n"`).
 * All the RESP2 old conversions still apply unless specified above.

--- a/commands/module-load.md
+++ b/commands/module-load.md
@@ -5,7 +5,7 @@ specified by the `path` argument. The `path` should be the absolute path of the
 library, including the full filename. Any additional arguments are passed
 unmodified to the module.
 
-**Note**: modules can also be loaded at server startup with 'loadmodule'
+**Note**: modules can also be loaded at server startup with `loadmodule`
 configuration directive in `redis.conf`.
 
 @return

--- a/commands/stralgo.md
+++ b/commands/stralgo.md
@@ -100,5 +100,5 @@ Finally to also have the match len:
 For the LCS algorithm:
 
 * Without modifiers the string representing the longest common substring is returned.
-* When LEN is given the command returns the length of the longest common substring.
-* When IDX is given the command returns an array with the LCS length and all the ranges in both the strings, start and end offset for each string, where there are matches. When WITHMATCHLEN is given each array representing a match will also have the length of the match (see examples).
+* When `LEN` is given the command returns the length of the longest common substring.
+* When `IDX` is given the command returns an array with the LCS length and all the ranges in both the strings, start and end offset for each string, where there are matches. When `WITHMATCHLEN` is given each array representing a match will also have the length of the match (see examples).

--- a/commands/xreadgroup.md
+++ b/commands/xreadgroup.md
@@ -16,7 +16,7 @@ Without consumer groups, just using `XREAD`, all the clients are served with all
 
 Within a consumer group, a given consumer (that is, just a client consuming messages from the stream), has to identify with an unique *consumer name*. Which is just a string.
 
-One of the guarantees of consumer groups is that a given consumer can only see the history of messages that were delivered to it, so a message has just a single owner. However there is a special feature called *message claiming* that allows other consumers to claim messages in case there is a non recoverable failure of some consumer. In order to implement such semantics, consumer groups require explicit acknowledgement of the messages successfully processed by the consumer, via the `XACK` command. This is needed because the stream will track, for each consumer group, who is processing what message.
+One of the guarantees of consumer groups is that a given consumer can only see the history of messages that were delivered to it, so a message has just a single owner. However there is a special feature called *message claiming* that allows other consumers to claim messages in case there is a non recoverable failure of some consumer. In order to implement such semantics, consumer groups require explicit acknowledgment of the messages successfully processed by the consumer, via the `XACK` command. This is needed because the stream will track, for each consumer group, who is processing what message.
 
 This is how to understand if you want to use a consumer group or not:
 

--- a/wordlist
+++ b/wordlist
@@ -40,6 +40,7 @@ Geohashes
 Geospatial
 GitHub
 Google
+HMAC
 HLL
 HLLs
 HOWTO
@@ -55,6 +56,7 @@ IRC
 Inline
 JPEG
 JSON
+LCS
 LDB
 LF
 LFU
@@ -89,6 +91,7 @@ OOM
 OSGEO
 Opteron
 PEL
+PELs
 PHP
 PINGs
 POSIX
@@ -219,10 +222,12 @@ failback
 failover
 failovers
 fanout
+fao
 fdatasync
 filesystem
 firewalled
 firewalling
+fo
 freenode
 fsync
 functionalities
@@ -292,6 +297,7 @@ netsplits
 newjobs
 nils
 noeviction
+nopass
 noscript
 numactl
 online
@@ -311,6 +317,7 @@ probabilistically
 proc
 programmatically
 prstat
+pseudorandom
 pubsub
 qsort
 queueing
@@ -356,12 +363,14 @@ sismember
 slowlog
 smaps
 snapshotting
+somekey
 startup
 strace
 struct
 subcommand
 subcommands
 suboptimal
+subsequence
 substring
 swappability
 syscall
@@ -403,6 +412,7 @@ variadic
 versa
 versioned
 versioning
+virginia
 virtualization
 virtualized
 vmstat


### PR DESCRIPTION
After @wingunder's #1399, #1400 \& #1401 (ty), it seemed like a good idea to vet out the existing spelling errors and re-introduce the spell check on PRs.