### PR TITLE
Add GET parameter to SET command

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2818,6 +2818,14 @@
           "XX"
         ],
         "optional": true
+      },
+      {
+        "name": "get",
+        "type": "enum",
+        "enum": [
+          "GET"
+        ],
+        "optional": true
       }
     ],
     "since": "1.0.0",

--- a/commands/getset.md
+++ b/commands/getset.md
@@ -15,6 +15,8 @@ GETSET mycounter "0"
 GET mycounter
 ```
 
+As per Redis 6.2, GETSET is considered deprecated. Please use `SET` with `GET` parameter in new code.
+
 @return
 
 @bulk-string-reply: the old value stored at `key`, or `nil` when `key` did not exist.

--- a/commands/set.md
+++ b/commands/set.md
@@ -11,18 +11,21 @@ The `SET` command supports a set of options that modify its behavior:
 * `NX` -- Only set the key if it does not already exist.
 * `XX` -- Only set the key if it already exist.
 * `KEEPTTL` -- Retain the time to live associated with the key.
+* `GET` -- Return the old value stored at key, or nil when key did not exist.
 
-Note: Since the `SET` command options can replace `SETNX`, `SETEX`, `PSETEX`, it is possible that in future versions of Redis these three commands will be deprecated and finally removed.
+Note: Since the `SET` command options can replace `SETNX`, `SETEX`, `PSETEX`, `GETSET`, it is possible that in future versions of Redis these three commands will be deprecated and finally removed.
 
 @return
 
 @simple-string-reply: `OK` if `SET` was executed correctly.
-@nil-reply: a Null Bulk Reply is returned if the `SET` operation was not performed because the user specified the `NX` or `XX` option but the condition was not met.
+@bulk-string-reply: when `GET` option is set, the old value stored at key, or nil when key did not exist.
+@nil-reply: a Null Bulk Reply is returned if the `SET` operation was not performed because the user specified the `NX` or `XX` option but the condition was not met or if user specified the `NX` and `GET` options that do not met.
 
 @history
 
 * `>= 2.6.12`: Added the `EX`, `PX`, `NX` and `XX` options.
 * `>= 6.0`: Added the `KEEPTTL` option.
+* `>= 6.2`: Added the `GET` option.
 
 @examples
 


### PR DESCRIPTION
Closes #2349

Add optional GET parameter to SET command in order to set a new value to
a key and retrieve the old key value. With this change we can deprecate
`GETSET` command and use only the SET command with the GET parameter.