### PR TITLE
Rewrite all links to redis.io with https scheme.

### DIFF
--- a/commands/set.md
+++ b/commands/set.md
@@ -38,7 +38,7 @@ SET anotherkey "will expire in a minute" EX 60
 
 ## Patterns
 
-**Note:** The following pattern is discouraged in favor of [the Redlock algorithm](http://redis.io/topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
+**Note:** The following pattern is discouraged in favor of [the Redlock algorithm](https://redis.io/topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
 
 The command `SET resource-name anystring NX EX max-lock-time` is a simple way to implement a locking system with Redis.
 

--- a/commands/setnx.md
+++ b/commands/setnx.md
@@ -22,7 +22,7 @@ GET mykey
 
 **Please note that:**
 
-1. The following pattern is discouraged in favor of [the Redlock algorithm](http://redis.io/topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
+1. The following pattern is discouraged in favor of [the Redlock algorithm](https://redis.io/topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
 2. We document the old pattern anyway because certain existing implementations link to this page as a reference. Moreover it is an interesting example of how Redis commands can be used in order to mount programming primitives.
 3. Anyway even assuming a single-instance locking primitive, starting with 2.6.12 it is possible to create a much simpler locking primitive, equivalent to the one discussed here, using the `SET` command to acquire the lock, and a simple Lua script to release the lock. The pattern is documented in the `SET` command page.
 

--- a/topics/clients.md
+++ b/topics/clients.md
@@ -153,11 +153,11 @@ In the above example session two clients are connected to the Redis server. The 
 * **name**: The client name as set by `CLIENT SETNAME`.
 * **age**: The number of seconds the connection existed for.
 * **idle**: The number of seconds the connection is idle.
-* **flags**: The kind of client (N means normal client, check the [full list of flags](http://redis.io/commands/client-list)).
+* **flags**: The kind of client (N means normal client, check the [full list of flags](https://redis.io/commands/client-list)).
 * **omem**: The amount of memory used by the client for the output buffer.
 * **cmd**: The last executed command.
 
-See the [CLIENT LIST](http://redis.io/commands/client-list) documentation for the full list of fields and their meaning.
+See the [CLIENT LIST](https://redis.io/commands/client-list) documentation for the full list of fields and their meaning.
 
 Once you have the list of clients, you can easily close the connection with a client using the `CLIENT KILL` command specifying the client address as argument.
 

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -273,7 +273,7 @@ the node was pinged and the last time the pong was received, the current
 *configuration epoch* of the node (explained later in this specification),
 the link state and finally the set of hash slots served.
 
-A detailed [explanation of all the node fields](http://redis.io/commands/cluster-nodes) is described in the `CLUSTER NODES` documentation.
+A detailed [explanation of all the node fields](https://redis.io/commands/cluster-nodes) is described in the `CLUSTER NODES` documentation.
 
 The `CLUSTER NODES` command can be sent to any node in the cluster and provides the state of the cluster and the information for each node according to the local view the queried node has of the cluster.
 

--- a/topics/data-types-intro.md
+++ b/topics/data-types-intro.md
@@ -548,7 +548,7 @@ as well, like `HINCRBY`:
     > hincrby user:1000 birthyear 10
     (integer) 1997
 
-You can find the [full list of hash commands in the documentation](http://redis.io/commands#hash).
+You can find the [full list of hash commands in the documentation](https://redis.io/commands#hash).
 
 It is worth noting that small hashes (i.e., a few elements with small values) are
 encoded in special way in memory that make them very memory efficient.

--- a/topics/indexes.md
+++ b/topics/indexes.md
@@ -547,7 +547,7 @@ our coordinates. Both variables max value is 400.
 The blue box in the picture represents our query. We want all the points
 where `x` is between 50 and 100, and where `y` is between 100 and 300.
 
-![Points in the space](http://redis.io/images/redisdoc/2idx_0.png)
+![Points in the space](https://redis.io/images/redisdoc/2idx_0.png)
 
 In order to represent data that makes these kinds of queries fast to perform,
 we start by padding our numbers with 0. So for example imagine we want to
@@ -586,7 +586,7 @@ variable is between 70 and 79, and the `y` variable is between 200 and 209.
 We can write random points in this interval, in order to identify this
 specific area:
 
-![Small area](http://redis.io/images/redisdoc/2idx_1.png)
+![Small area](https://redis.io/images/redisdoc/2idx_1.png)
 
 So the above lexicographic query allows us to easily query for points in
 a specific square in the picture. However the square may be too small for
@@ -601,7 +601,7 @@ This time the range represents all the points where `x` is between 0 and 99
 and `y` is between 200 and 299. Drawing random points in this interval
 shows us this larger area:
 
-![Large area](http://redis.io/images/redisdoc/2idx_2.png)
+![Large area](https://redis.io/images/redisdoc/2idx_2.png)
 
 Oops now our area is ways too big for our query, and still our search box is
 not completely included. We need more granularity, but we can easily obtain

--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -105,7 +105,7 @@ costs more memory. However the approximation is virtually equivalent for the
 application using Redis. The following is a graphical comparison of how
 the LRU approximation used by Redis compares with true LRU.
 
-![LRU comparison](http://redis.io/images/redisdoc/lru_comparison.png)
+![LRU comparison](https://redis.io/images/redisdoc/lru_comparison.png)
 
 The test to generate the above graphs filled a Redis server with a given number of keys. The keys were accessed from the first to the last, so that the first keys are the best candidates for eviction using an LRU algorithm. Later more 50% of keys are added, in order to force half of the old keys to be evicted.
 

--- a/topics/memory-optimization.md
+++ b/topics/memory-optimization.md
@@ -187,7 +187,7 @@ To store user keys, Redis allocates at most as much memory as the `maxmemory`
 setting enables (however there are small extra allocations possible).
 
 The exact value can be set in the configuration file or set later via
-`CONFIG SET` (see [Using memory as an LRU cache for more info](http://redis.io/topics/lru-cache)). There are a few things that should be noted about how
+`CONFIG SET` (see [Using memory as an LRU cache for more info](https://redis.io/topics/lru-cache)). There are a few things that should be noted about how
 Redis manages memory:
 
 * Redis will not always free up (return) memory to the OS when keys are removed.

--- a/topics/partitioning.md
+++ b/topics/partitioning.md
@@ -116,4 +116,4 @@ Clients supporting consistent hashing
 
 An alternative to Twemproxy is to use a client that implements client side partitioning via consistent hashing or other similar algorithms. There are multiple Redis clients with support for consistent hashing, notably [Redis-rb](https://github.com/redis/redis-rb) and [Predis](https://github.com/nrk/predis).
 
-Please check the [full list of Redis clients](http://redis.io/clients) to check if there is a mature client with consistent hashing implementation for your language.
+Please check the [full list of Redis clients](https://redis.io/clients) to check if there is a mature client with consistent hashing implementation for your language.

--- a/topics/pipelining.md
+++ b/topics/pipelining.md
@@ -129,7 +129,7 @@ Pipelining VS Scripting
 
 Using [Redis scripting](/commands/eval) (available in Redis version 2.6 or greater) a number of use cases for pipelining can be addressed more efficiently using scripts that perform a lot of the work needed at the server side. A big advantage of scripting is that it is able to both read and write data with minimal latency, making operations like *read, compute, write* very fast (pipelining can't help in this scenario since the client needs the reply of the read command before it can call the write command).
 
-Sometimes the application may also want to send `EVAL` or `EVALSHA` commands in a pipeline. This is entirely possible and Redis explicitly supports it with the [SCRIPT LOAD](http://redis.io/commands/script-load) command (it guarantees that `EVALSHA` can be called without the risk of failing).
+Sometimes the application may also want to send `EVAL` or `EVALSHA` commands in a pipeline. This is entirely possible and Redis explicitly supports it with the [SCRIPT LOAD](https://redis.io/commands/script-load) command (it guarantees that `EVALSHA` can be called without the risk of failing).
 
 Appendix: Why are busy loops slow even on the loopback interface?
 ---

--- a/topics/quickstart.md
+++ b/topics/quickstart.md
@@ -19,7 +19,7 @@ Redis has no dependencies other than a working GCC compiler and libc.
 Installing it using the package manager of your Linux distribution is somewhat
 discouraged as usually the available version is not the latest.
 
-You can either download the latest Redis tar ball from the [redis.io](http://redis.io) web site, or you can alternatively use this special URL that always points to the latest stable Redis version, that is, [http://download.redis.io/redis-stable.tar.gz](http://download.redis.io/redis-stable.tar.gz).
+You can either download the latest Redis tar ball from the [redis.io](https://redis.io) web site, or you can alternatively use this special URL that always points to the latest stable Redis version, that is, [http://download.redis.io/redis-stable.tar.gz](http://download.redis.io/redis-stable.tar.gz).
 
 In order to compile Redis follow these simple steps:
 
@@ -83,7 +83,7 @@ Another interesting way to run redis-cli is without arguments: the program will 
     redis 127.0.0.1:6379> get mykey
     "somevalue"
 
-At this point you are able to talk with Redis. It is the right time to pause a bit with this tutorial and start the [fifteen minutes introduction to Redis data types](http://redis.io/topics/data-types-intro) in order to learn a few Redis commands. Otherwise if you already know a few basic Redis commands you can keep reading.
+At this point you are able to talk with Redis. It is the right time to pause a bit with this tutorial and start the [fifteen minutes introduction to Redis data types](https://redis.io/topics/data-types-intro) in order to learn a few Redis commands. Otherwise if you already know a few basic Redis commands you can keep reading.
 
 Securing Redis
 ===
@@ -109,7 +109,7 @@ Using Redis from your application
 Of course using Redis just from the command line interface is not enough as
 the goal is to use it from your application. In order to do so you need to
 download and install a Redis client library for your programming language.
-You'll find a [full list of clients for different languages in this page](http://redis.io/clients).
+You'll find a [full list of clients for different languages in this page](https://redis.io/clients).
 
 For instance if you happen to use the Ruby programming language our best advice
 is to use the [Redis-rb](https://github.com/redis/redis-rb) client.
@@ -135,12 +135,12 @@ commands calling methods. A short interactive example using Ruby:
 Redis persistence
 =================
 
-You can learn [how Redis persistence works on this page](http://redis.io/topics/persistence), however what is important to understand for a quick start is that by default, if you start Redis with the default configuration, Redis will spontaneously save the dataset only from time to time (for instance after at least five minutes if you have at least 100 changes in your data), so if you want your database to persist and be reloaded after a restart make sure to call the **SAVE** command manually every time you want to force a data set snapshot. Otherwise make sure to shutdown the database using the **SHUTDOWN** command:
+You can learn [how Redis persistence works on this page](https://redis.io/topics/persistence), however what is important to understand for a quick start is that by default, if you start Redis with the default configuration, Redis will spontaneously save the dataset only from time to time (for instance after at least five minutes if you have at least 100 changes in your data), so if you want your database to persist and be reloaded after a restart make sure to call the **SAVE** command manually every time you want to force a data set snapshot. Otherwise make sure to shutdown the database using the **SHUTDOWN** command:
 
     $ redis-cli shutdown
 
 This way Redis will make sure to save the data on disk before quitting.
-Reading the [persistence page](http://redis.io/topics/persistence) is strongly suggested in order to better understand how Redis persistence works.
+Reading the [persistence page](https://redis.io/topics/persistence) is strongly suggested in order to better understand how Redis persistence works.
 
 Installing Redis more properly
 ==============================

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -143,7 +143,7 @@ also to retrieve its score if it exists, we use the `ZSCORE` command:
 
 Sorted Sets are a very powerful data structure, you can query elements by
 score range, lexicographically, in reverse order, and so forth.
-To know more [please check the Sorted Set sections in the official Redis commands documentation](http://redis.io/commands/#sorted_set).
+To know more [please check the Sorted Set sections in the official Redis commands documentation](https://redis.io/commands/#sorted_set).
 
 The Hash data type
 ---


### PR DESCRIPTION
On some pages, Firefox shows a warning in the url bar when visiting the website over https, caused by images being loaded over http.

For the sake of completeness, here I've moved all internal links to use https scheme.

<img width="1551" alt="redis docs" src="https://user-images.githubusercontent.com/316923/95495002-b0bf3f00-0996-11eb-88fd-55adaa7276cd.png">