### PR TITLE
Switch GEORADIUS example arg ordering to match commands.json

### DIFF
--- a/commands/georadius.md
+++ b/commands/georadius.md
@@ -60,5 +60,5 @@ Both commands were introduced in Redis 3.2.10 and Redis 4.0.0 respectively.
 GEOADD Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
 GEORADIUS Sicily 15 37 200 km WITHDIST
 GEORADIUS Sicily 15 37 200 km WITHCOORD
-GEORADIUS Sicily 15 37 200 km WITHDIST WITHCOORD
+GEORADIUS Sicily 15 37 200 km WITHCOORD WITHDIST
 ```


### PR DESCRIPTION
commands.json specifies `WITHCOORD` comes before `WITHDIST`: https://github.com/redis/redis-doc/blob/8fa5ba577f3f9a90f55027c5a0d83bec8271ad27/commands.json#L1319-L1334