### PR TITLE
Add handy-redis to list of clients

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -787,21 +787,21 @@
   },
 
   {
+    "name": "xredis",
+    "language": "Node.js",
+    "repository": "https://github.com/razaellahi/xredis",
+    "description": "Redis client with redis ACL features",
+    "authors": ["razaellahi531"],
+    "recommended": false,
+    "active": true
+  },
+  
+  {
     "name": "node_redis",
     "language": "Node.js",
     "repository": "https://github.com/NodeRedis/node_redis",
     "description": "Recommended client for node.",
     "authors": ["mranney"],
-    "recommended": true,
-    "active": true
-  },
-
-  {
-    "name": "ioredis",
-    "language": "Node.js",
-    "repository": "https://github.com/luin/ioredis",
-    "description": "A delightful, performance-focused and full-featured Redis client. Supports Cluster, Sentinel, Pipelining and Lua Scripting",
-    "authors": ["luinlee"],
     "recommended": true,
     "active": true
   },
@@ -836,16 +836,6 @@
   },
   
   {
-    "name": "xredis",
-    "language": "Node.js",
-    "repository": "https://github.com/razaellahi/xredis",
-    "description": "Redis client with redis ACL features",
-    "authors": ["razaellahi531"],
-    "recommended": false,
-    "active": true
-  },
-  
-  {
     "name": "then-redis",
     "language": "Node.js",
     "repository": "https://github.com/mjackson/then-redis",
@@ -860,6 +850,16 @@
     "repository": "https://github.com/fictorial/redis-node-client",
     "description": "No longer maintained, does not work with node 0.3.",
     "authors": []
+  },
+
+  {
+    "name": "ioredis",
+    "language": "Node.js",
+    "repository": "https://github.com/luin/ioredis",
+    "description": "A delightful, performance-focused and full-featured Redis client. Supports Cluster, Sentinel, Pipelining and Lua Scripting",
+    "authors": ["luinlee"],
+    "recommended": true,
+    "active": true
   },
 
   {

--- a/clients.json
+++ b/clients.json
@@ -785,17 +785,7 @@
     "authors": [],
     "active": true
   },
-  
-  {
-    "name": "xredis",
-    "language": "Node.js",
-    "repository": "https://github.com/razaellahi/xredis",
-    "description": "Redis client with redis ACL features",
-    "authors": ["razaellahi531"],
-    "recommended": true,
-    "active": true
-  },
-  
+
   {
     "name": "node_redis",
     "language": "Node.js",
@@ -807,12 +797,32 @@
   },
 
   {
+    "name": "ioredis",
+    "language": "Node.js",
+    "repository": "https://github.com/luin/ioredis",
+    "description": "A delightful, performance-focused and full-featured Redis client. Supports Cluster, Sentinel, Pipelining and Lua Scripting",
+    "authors": ["luinlee"],
+    "recommended": true,
+    "active": true
+  },
+
+  {
+    "name": "handy-redis",
+    "language": "Node.js",
+    "repository": "https://github.com/mmkal/handy-redis",
+    "description": "A wrapper around node_redis with Promise and TypeScript support.",
+    "authors": ["mmkal"],
+    "recommended": true,
+    "active": true
+  },
+
+  {
     "name": "thunk-redis",
     "language": "Node.js",
     "repository": "https://github.com/thunks/thunk-redis",
     "description": "A thunk/promise-based redis client with pipelining and cluster.",
     "authors": ["izensh"],
-    "active": true
+    "active": false
   },
 
   {
@@ -822,16 +832,26 @@
     "description": "♠ Spade, a full-featured modular client for node.",
     "authors": ["44gtti"],
     "recommended": false,
+    "active": false
+  },
+  
+  {
+    "name": "xredis",
+    "language": "Node.js",
+    "repository": "https://github.com/razaellahi/xredis",
+    "description": "Redis client with redis ACL features",
+    "authors": ["razaellahi531"],
+    "recommended": false,
     "active": true
   },
-
+  
   {
     "name": "then-redis",
     "language": "Node.js",
     "repository": "https://github.com/mjackson/then-redis",
     "description": "A small, promise-based Redis client for node",
     "authors": ["mjackson"],
-    "active": true
+    "active": false
   },
 
   {
@@ -840,16 +860,6 @@
     "repository": "https://github.com/fictorial/redis-node-client",
     "description": "No longer maintained, does not work with node 0.3.",
     "authors": []
-  },
-
-  {
-    "name": "ioredis",
-    "language": "Node.js",
-    "repository": "https://github.com/luin/ioredis",
-    "description": "A delightful, performance-focused and full-featured Redis client. Supports Cluster, Sentinel, Pipelining and Lua Scripting",
-    "authors": ["luinlee"],
-    "recommended": true,
-    "active": true
   },
 
   {
@@ -878,7 +888,7 @@
     "repository": "https://github.com/h0x91b/fast-redis-cluster",
     "description": "Simple and fast cluster driver with error handling, uses redis-fast-driver as main adapter and node_redis as backup for windows",
     "authors": ["h0x91b"],
-    "active": true
+    "active": false
   },
 
   {

--- a/clients.json
+++ b/clients.json
@@ -812,7 +812,6 @@
     "repository": "https://github.com/mmkal/handy-redis",
     "description": "A wrapper around node_redis with Promise and TypeScript support.",
     "authors": [],
-    "recommended": true,
     "active": true
   },
 

--- a/clients.json
+++ b/clients.json
@@ -811,7 +811,7 @@
     "language": "Node.js",
     "repository": "https://github.com/mmkal/handy-redis",
     "description": "A wrapper around node_redis with Promise and TypeScript support.",
-    "authors": ["mmkal"],
+    "authors": [],
     "recommended": true,
     "active": true
   },

--- a/clients.json
+++ b/clients.json
@@ -785,7 +785,7 @@
     "authors": [],
     "active": true
   },
-
+  
   {
     "name": "xredis",
     "language": "Node.js",
@@ -834,7 +834,7 @@
     "recommended": false,
     "active": false
   },
-  
+
   {
     "name": "then-redis",
     "language": "Node.js",


### PR DESCRIPTION
Hello - this is to add a [client I maintain](https://npmjs.com/package/handy-redis) to clients.json

I also re-ordered some of the clients and updated some "active" flags (rough method I used: no activity for >1 year and very few downloads => not active).