### PR TITLE
Add documentation for the new zdiff/zdiffstore commands

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -3547,6 +3547,52 @@
     "since": "2.0.0",
     "group": "sorted_set"
   },
+  "ZDIFF": {
+    "summary": "Subtract multiple sorted sets",
+    "complexity": "O(N)+O(M*log(M)) worst case with N is the total number of elements in all given sets and M being the number of elements in the resulting sorted set.",
+    "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "multiple": true
+      },
+      {
+        "name": "withscores",
+        "type": "enum",
+        "enum": [
+          "WITHSCORES"
+        ],
+        "optional": true
+      }
+    ],
+    "since": "6.2.0",
+    "group": "sorted_set"
+  },
+  "ZDIFFSTORE": {
+    "summary": "Subtract multiple sorted sets and store the resulting sorted set in a new key",
+    "complexity": "O(N)+O(M*log(M)) worst case with N is the total number of elements in all given sets and M being the number of elements in the resulting sorted set.",
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "key"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "multiple": true
+      }
+    ],
+    "since": "6.2.0",
+    "group": "sorted_set"
+  },
   "ZINCRBY": {
     "summary": "Increment the score of a member in a sorted set",
     "complexity": "O(log(N)) where N is the number of elements in the sorted set.",

--- a/commands.json
+++ b/commands.json
@@ -3574,7 +3574,7 @@
   },
   "ZDIFFSTORE": {
     "summary": "Subtract multiple sorted sets and store the resulting sorted set in a new key",
-    "complexity": "O(N)+O(M*log(M)) worst case with N is the total number of elements in all given sets and M being the number of elements in the resulting sorted set.",
+    "complexity": "O(N + (M-L)log(N)) worst case, where N is the total number of elements in all the sets, M is the size of the first set, and L is the size of the result set.",
     "arguments": [
       {
         "name": "destination",

--- a/commands.json
+++ b/commands.json
@@ -3549,7 +3549,7 @@
   },
   "ZDIFF": {
     "summary": "Subtract multiple sorted sets",
-    "complexity": "O(N)+O(M*log(M)) worst case with N is the total number of elements in all given sets and M being the number of elements in the resulting sorted set.",
+    "complexity": "O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the result set.",
     "arguments": [
       {
         "name": "numkeys",
@@ -3574,7 +3574,7 @@
   },
   "ZDIFFSTORE": {
     "summary": "Subtract multiple sorted sets and store the resulting sorted set in a new key",
-    "complexity": "O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the  result set.",
+    "complexity": "O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the result set.",
     "arguments": [
       {
         "name": "destination",

--- a/commands.json
+++ b/commands.json
@@ -3574,7 +3574,7 @@
   },
   "ZDIFFSTORE": {
     "summary": "Subtract multiple sorted sets and store the resulting sorted set in a new key",
-    "complexity": "O(N + (M-L)log(N)) worst case, where N is the total number of elements in all the sets, M is the size of the first set, and L is the size of the result set.",
+    "complexity": "O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the  result set.",
     "arguments": [
       {
         "name": "destination",

--- a/commands/command.md
+++ b/commands/command.md
@@ -104,8 +104,12 @@ Cluster client needs to parse commands marked `movablekeys` to locate all releva
 Complete list of commands currently requiring key location parsing:
 
   - `SORT` - optional `STORE` key, optional `BY` weights, optional `GET` keys
+  - `ZUNION` - keys stop when `WEIGHT` or `AGGREGATE` starts
   - `ZUNIONSTORE` - keys stop when `WEIGHT` or `AGGREGATE` starts
+  - `ZINTER` - keys stop when `WEIGHT` or `AGGREGATE` starts
   - `ZINTERSTORE` - keys stop when `WEIGHT` or `AGGREGATE` starts
+  - `ZDIFF` - keys stop after `numkeys` count arguments
+  - `ZDIFFSTORE` - keys stop after `numkeys` count arguments
   - `EVAL` - keys stop after `numkeys` count arguments
   - `EVALSHA` - keys stop after `numkeys` count arguments
 

--- a/commands/zdiff.md
+++ b/commands/zdiff.md
@@ -1,0 +1,19 @@
+This command is similar to `ZDIFFSTORE`, but instead of storing the resulting
+sorted set, it is returned to the client.
+
+@return
+
+@array-reply: the result of the difference (optionally with their scores, in case
+the `WITHSCORES` option is given).
+
+@examples
+
+```cli
+ZADD zset1 1 "one"
+ZADD zset1 2 "two"
+ZADD zset1 3 "three"
+ZADD zset2 1 "one"
+ZADD zset2 2 "two"
+ZDIFF 2 zset1 zset2
+ZDIFF 2 zset1 zset2 WITHSCORES
+```

--- a/commands/zdiffstore.md
+++ b/commands/zdiffstore.md
@@ -1,6 +1,6 @@
-Computes the difference of `numkeys` sorted sets given by the specified keys,
-between the first and all the successive sets, and stores the result in
-`destination`.
+Computes the difference between the first and all successive input sorted sets
+and stores the result in `destination`. The total number of input keys is
+specified by `numkeys`.
 
 Keys that do not exist are considered to be empty sets.
 

--- a/commands/zdiffstore.md
+++ b/commands/zdiffstore.md
@@ -1,0 +1,25 @@
+Computes the difference between the first set and all the successive sorted
+sets given by the specified keys, and stores the result in `destination`.
+It is mandatory to provide the number of input keys (`numkeys`) before passing
+the input keys.
+
+Keys that do not exist are considered to be empty sets.
+
+If `destination` already exists, it is overwritten.
+
+@return
+
+@integer-reply: the number of elements in the resulting sorted set at
+`destination`.
+
+@examples
+
+```cli
+ZADD zset1 1 "one"
+ZADD zset1 2 "two"
+ZADD zset1 3 "three"
+ZADD zset2 1 "one"
+ZADD zset2 2 "two"
+ZDIFFSTORE out 2 zset1 zset2
+ZRANGE out 0 -1 WITHSCORES
+```

--- a/commands/zdiffstore.md
+++ b/commands/zdiffstore.md
@@ -1,7 +1,6 @@
-Computes the difference between the first set and all the successive sorted
-sets given by the specified keys, and stores the result in `destination`.
-It is mandatory to provide the number of input keys (`numkeys`) before passing
-the input keys.
+Computes the difference of `numkeys` sorted sets given by the specified keys,
+between the first and all the successive sets, and stores the result in
+`destination`.
 
 Keys that do not exist are considered to be empty sets.
 

--- a/topics/notifications.md
+++ b/topics/notifications.md
@@ -133,7 +133,7 @@ Different commands generate different kind of events according to the following 
 * `ZREM` generates a single `zrem` event even when multiple elements are deleted. When the resulting sorted set is empty and the key is generated, an additional `del` event is generated.
 * `ZREMBYSCORE` generates a single `zrembyscore` event. When the resulting sorted set is empty and the key is generated, an additional `del` event is generated.
 * `ZREMBYRANK` generates a single `zrembyrank` event. When the resulting sorted set is empty and the key is generated, an additional `del` event is generated.
-* `ZINTERSTORE` and `ZUNIONSTORE` respectively generate `zinterstore` and `zunionstore` events. In the special case the resulting sorted set is empty, and the key where the result is stored already exists, a `del` event is generated since the key is removed.
+* `ZDIFFSTORE`, `ZINTERSTORE` and `ZUNIONSTORE` respectively generate `zdiffstore`, `zinterstore` and `zunionstore` events. In the special case the resulting sorted set is empty, and the key where the result is stored already exists, a `del` event is generated since the key is removed.
 * `XADD` generates an `xadd` event, possibly followed an `xtrim` event when used with the `MAXLEN` subcommand.
 * `XDEL` generates a single `xdel` event even when multiple entries are deleted.
 * `XGROUP CREATE` generates an `xgroup-create` event.


### PR DESCRIPTION
Add documentation for the new commands added in https://github.com/redis/redis/pull/7961

I took the liberty to also add missing entries for the zinter and zunion commands in the "Movable Keys" section of COMMAND.

There's one thing I need help with: the complexity of these new commands. My math skills are rusty, so I didn't even try very hard to check it. I just adapted the complexity of SDIFF, but I'm thinking it is too broad, or maybe even incorrect. Basically, ZDIFF and SDIFF use the same algorithms, which can be one of two depending on the size of the input sets. I thought about just doing `O(min(a, b))`, but maybe there's a better way. The complexity stated in the documentation is the one from algorithm 2 in the code.