### PR TITLE
Clarify the usage of maxlen with a value of 0

### DIFF
--- a/commands/lpos.md
+++ b/commands/lpos.md
@@ -55,6 +55,8 @@ When `COUNT` is used and no match is found, an empty array is returned. However 
 
 Finally, the `MAXLEN` option tells the command to compare the provided element only with a given maximum number of list items. So for instance specifying `MAXLEN 1000` will make sure that the command performs only 1000 comparisons, effectively running the algorithm on a subset of the list (the first part or the last part depending on the fact we use a positive or negative rank). This is useful to limit the maximum complexity of the command. It is also useful when we expect the match to be found very early, but want to be sure that in case this is not true, the command does not take too much time to run.
 
+When `MAXLEN` is used, it is possible to specify 0 as the maximum number of comparisons, as a way to tell the command we want unlimited comparisons. This is better than giving a very large `MAXLEN` option because it is more general.
+
 @return
 
 The command returns the integer representing the matching element, or null if there is no match. However, if the `COUNT` option is given the command returns an array (empty if there are no matches).


### PR DESCRIPTION
To keep it consistent I decided to use the same wording as used for `Count` 0

Fixes #1429 

