### PR TITLE
Document potential feedback loop with BCAST and maxmemory-policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ The formatter has the following dependencies:
 * Redcarpet
 * Nokogiri
 * The `par` tool
+* batch
 
 Installation of the Ruby gems:
 
 ```
-gem install redcarpet nokogiri
+gem install redcarpet nokogiri batch
 ```
 
 Installation of par (OSX):

--- a/clients.json
+++ b/clients.json
@@ -1213,6 +1213,15 @@
     "active": true
   },
   {
+    "name": "redis-async",
+    "language": "OCaml",
+    "repository": "https://github.com/janestreet/redis-async",
+    "url": "https://github.com/janestreet/redis-async",
+    "description": "A Redis client for OCaml Async applications with a strongly-typed API and client tracking support.",
+    "authors": [ "janestreet", "lukepalmer" ],
+    "active": true
+  },
+  {
     "name": "Nhiredis",
     "language": "C#",
     "repository": "https://github.com/mhowlett/Nhiredis",


### PR DESCRIPTION
Add documentation for a potentially serious pitfall when using broadcast invalidation.