### PR TITLE
Adds nested arguments

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -4341,8 +4341,33 @@
         "type": "key"
       },
       {
-        "name": "ID",
-        "type": "string"
+        "type": "block",
+        "block": [
+          {
+            "command": "MAXLEN"
+          },
+          {
+            "type": "block",
+            "block": [
+              {
+                "command": "~",
+                "optional": true
+              },
+              {
+                "name": "length",
+                "type": "integer"
+              }
+            ]
+          }
+        ],
+        "optional": true
+      },
+      {
+        "type": "enum",
+        "enum": [
+          "*",
+          "ID"
+        ]
       },
       {
         "name": [
@@ -4500,7 +4525,7 @@
         "multiple": true
       },
       {
-        "name": "id",
+        "name": "ID",
         "type": "string",
         "multiple": true
       }
@@ -4513,30 +4538,56 @@
     "complexity": "O(1) for all the subcommands, with the exception of the DESTROY subcommand which takes an additional O(M) time in order to delete the M entries inside the consumer group pending entries list (PEL).",
     "arguments": [
       {
-        "command": "CREATE",
-        "name": [
-          "key",
-          "groupname",
-          "id-or-$"
-        ],
-        "type": [
-          "key",
-          "string",
-          "string"
+        "type": "block",
+        "block": [
+          {
+            "command": "CREATE",
+            "name": [
+              "key",
+              "groupname"
+            ],
+            "type": [
+              "key",
+              "string"
+            ]
+          },
+          {
+            "name": "id",
+            "type": "enum",
+            "enum": [
+              "ID",
+              "$"
+            ]
+          },
+          {
+            "command": "MKSTREAM",
+            "optional": true
+          }
         ],
         "optional": true
       },
       {
-        "command": "SETID",
-        "name": [
-          "key",
-          "groupname",
-          "id-or-$"
-        ],
-        "type": [
-          "key",
-          "string",
-          "string"
+        "type": "block",
+        "block": [
+          {
+            "command": "SETID",
+            "name": [
+              "key",
+              "groupname"
+            ],
+            "type": [
+              "key",
+              "string"
+            ]
+          },
+          {
+            "name": "id",
+            "type": "enum",
+            "enum": [
+              "ID",
+              "$"
+            ]
+          }
         ],
         "optional": true
       },
@@ -4735,27 +4786,38 @@
         "type": "string"
       },
       {
-        "name": [
-          "start",
-          "end",
-          "count"
+        "type": "block",
+        "block": [
+          {
+            "name": "start",
+            "type": "string"
+          },
+          {
+            "name": "end",
+            "type": "string"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "filter",
+            "type": "block",
+            "block": [
+              {
+                "name": "consumer",
+                "type": "string"
+              },
+              {
+                "command": "IDLE",
+                "name": "min-idle-time",
+                "type": "integer",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ],
-        "type": [
-          "string",
-          "string",
-          "integer"
-        ],
-        "optional": true
-      },
-      {
-        "name": "consumer",
-        "type": "string",
-        "optional": true
-      },
-      {
-        "command": "IDLE",
-        "name": "min-idle-time",
-        "type": "integer",
         "optional": true
       }
     ],

--- a/commands.json
+++ b/commands.json
@@ -4350,7 +4350,11 @@
             "type": "block",
             "block": [
               {
-                "command": "~",
+                "type": "enum",
+                "enum": [
+                  "=",
+                  "~"
+                ],
                 "optional": true
               },
               {
@@ -4404,16 +4408,21 @@
         ]
       },
       {
-        "name": "approx",
-        "type": "enum",
-        "enum": [
-          "~"
-        ],
-        "optional": true
-      },
-      {
-        "name": "count",
-        "type": "integer"
+        "type": "block",
+        "block": [
+          {
+            "type": "enum",
+            "enum": [
+              "=",
+              "~"
+            ],
+            "optional": true
+          },
+          {
+            "name": "length",
+            "type": "integer"
+          }
+        ]
       }
     ],
     "since": "5.0.0",

--- a/commands.json
+++ b/commands.json
@@ -4363,6 +4363,10 @@
         "optional": true
       },
       {
+        "command": "NOMKSTREAM",
+        "optional": true
+      },
+      {
         "type": "enum",
         "enum": [
           "*",

--- a/commands/xadd.md
+++ b/commands/xadd.md
@@ -49,7 +49,10 @@ IDs to match the one of this other system.
 ## Capped streams
 
 It is possible to limit the size of the stream to a maximum number of
-elements using the **MAXLEN** option. 
+elements using the **MAXLEN** option. By default, or when used with the `=`
+argument, the **MAXLEN** option performs an exact trimming. That means that the
+trimmed stream's length will be exactly the minimum between its original length
+and the specified maximum length.
 
 Trimming with **MAXLEN** can be expensive compared to just adding entries with 
 `XADD`: streams are represented by macro nodes into a radix tree, in order to

--- a/commands/xadd.md
+++ b/commands/xadd.md
@@ -1,6 +1,7 @@
 Appends the specified stream entry to the stream at the specified key.
 If the key does not exist, as a side effect of running this command the
-key is created with a stream value.
+key is created with a stream value. The creation of stream's key can be
+disabled with the `NOMKSTREAM` option.
 
 An entry is composed of a set of field-value pairs, it is basically a
 small dictionary. The field-value pairs are stored in the same order
@@ -77,6 +78,13 @@ For further information about Redis streams please check our
 The command returns the ID of the added entry. The ID is the one auto-generated
 if `*` is passed as ID argument, otherwise the command just returns the same ID
 specified by the user during insertion.
+
+The command returns a @nil-reply when used with the `NOMKSTREAM` option and the
+key doesn't exist.
+
+@history
+
+* `>= 6.2`: Added the `NOMKSTREAM` option.
 
 @examples
 

--- a/commands/xtrim.md
+++ b/commands/xtrim.md
@@ -10,6 +10,11 @@ the latest 1000 items:
 XTRIM mystream MAXLEN 1000
 ```
 
+By default, or when provided with the optional `=` argument, the command
+performs exact trimming. That means that the trimmed stream's length will be
+exactly the minimum between its original length and the specified maximum
+length.
+
 It is possible to give the command in the following special form in
 order to make it more efficient:
 


### PR DESCRIPTION
Relies on https://github.com/redis/redis-io/pull/221

Should fix #1007, #1008 and wrt to https://github.com/redis/redis/pull/7972#issuecomment-730867094

Also adds `XADD ... NOMKSTREAM` (https://github.com/redis/redis/pull/7910).

`XADD` before/after shots:
![image](https://user-images.githubusercontent.com/6059516/99823608-4684e700-2b5d-11eb-9d9b-0e606994f19b.png)
![image](https://user-images.githubusercontent.com/6059516/99887870-b922bf00-2c50-11eb-94e9-05bcc55c7f26.png)

`XGROUP` before/after shots:
![image](https://user-images.githubusercontent.com/6059516/99823688-58668a00-2b5d-11eb-8686-8650b4de279f.png)
![image](https://user-images.githubusercontent.com/6059516/99823708-5e5c6b00-2b5d-11eb-90b7-67aaeb10a260.png)

`XPENDING` before/after shots:
![image](https://user-images.githubusercontent.com/6059516/99823748-6b795a00-2b5d-11eb-9338-635953bdd613.png)
![image](https://user-images.githubusercontent.com/6059516/99823760-6f0ce100-2b5d-11eb-94dd-93e9a9e15ffc.png)
