### PR TITLE
Documented redis#8132: Redis main thread cpu time, and scrape system time

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -61,8 +61,8 @@ Here is the meaning of all fields in the **server** section:
 *   `run_id`: Random value identifying the Redis server (to be used by Sentinel
      and Cluster)
 *   `tcp_port`: TCP/IP listen port
-*   `server_time_in_microseconds`: Epoch-based, floating point, system time
-     with microsecond precision
+*   `server_time_in_usec`: Epoch-based, floating-point system time with
+     microsecond precision
 *   `uptime_in_seconds`: Number of seconds since Redis server start
 *   `uptime_in_days`: Same value expressed in days
 *   `hz`: The server's current frequency setting

--- a/commands/info.md
+++ b/commands/info.md
@@ -316,8 +316,8 @@ For each replica, the following line is added:
 
 Here is the meaning of all fields in the **cpu** section:
 
-*   `used_cpu_sys`: System CPU consumed by the Redis server, which is the sum of system CPU consumed by all threads in the Redis server process ( main thread and background threads )
-*   `used_cpu_user`: User CPU consumed by the Redis server, which is the sum of user CPU consumed by all threads in the Redis server process ( main thread and background threads )
+*   `used_cpu_sys`: System CPU consumed by the Redis server, which is the sum of system CPU consumed by all threads of the server process (main thread and background threads)
+*   `used_cpu_user`: User CPU consumed by the Redis server, which is the sum of user CPU consumed by all threads of the server process (main thread and background threads)
 *   `used_cpu_sys_children`: System CPU consumed by the background processes
 *   `used_cpu_user_children`: User CPU consumed by the background processes
 *   `used_cpu_sys_main_thread`: System CPU consumed by the Redis server main thread

--- a/commands/info.md
+++ b/commands/info.md
@@ -61,6 +61,8 @@ Here is the meaning of all fields in the **server** section:
 *   `run_id`: Random value identifying the Redis server (to be used by Sentinel
      and Cluster)
 *   `tcp_port`: TCP/IP listen port
+*   `server_time_in_microseconds`: Epoch-based, floating point, system time
+     with microsecond precision
 *   `uptime_in_seconds`: Number of seconds since Redis server start
 *   `uptime_in_days`: Same value expressed in days
 *   `hz`: The server's current frequency setting
@@ -314,10 +316,12 @@ For each replica, the following line is added:
 
 Here is the meaning of all fields in the **cpu** section:
 
-*   `used_cpu_sys`: System CPU consumed by the Redis server
-*   `used_cpu_user`:User CPU consumed by the Redis server
+*   `used_cpu_sys`: System CPU consumed by the Redis server, which is the sum of system CPU consumed by all threads in the Redis server process ( main thread and background threads )
+*   `used_cpu_user`: User CPU consumed by the Redis server, which is the sum of user CPU consumed by all threads in the Redis server process ( main thread and background threads )
 *   `used_cpu_sys_children`: System CPU consumed by the background processes
 *   `used_cpu_user_children`: User CPU consumed by the background processes
+*   `used_cpu_sys_main_thread`: System CPU consumed by the Redis server main thread
+*   `used_cpu_user_main_thread`: User CPU consumed by the Redis server main thread
 
 The **commandstats** section provides statistics based on the command type,
 including the number of calls, the total CPU time consumed by these commands,

--- a/commands/info.md
+++ b/commands/info.md
@@ -61,8 +61,7 @@ Here is the meaning of all fields in the **server** section:
 *   `run_id`: Random value identifying the Redis server (to be used by Sentinel
      and Cluster)
 *   `tcp_port`: TCP/IP listen port
-*   `server_time_in_usec`: Epoch-based, floating-point system time with
-     microsecond precision
+*   `server_time_in_usec`: Epoch-based system time with microsecond precision
 *   `uptime_in_seconds`: Number of seconds since Redis server start
 *   `uptime_in_days`: Same value expressed in days
 *   `hz`: The server's current frequency setting


### PR DESCRIPTION
This PR documents the soon to be added fields to the `INFO` command on PR https://github.com/redis/redis/pull/8132. Apart from it, tried to make more clear the differences between (`used_cpu_sys` and `used_cpu_sys_main_thread`), and ( `used_cpu_user` and `used_cpu_user_main_thread` )