### PR TITLE
Add Pottery Redlock implementation

### DIFF
--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -25,6 +25,7 @@ already available that can be used for reference.
 
 * [Redlock-rb](https://github.com/antirez/redlock-rb) (Ruby implementation). There is also a [fork of Redlock-rb](https://github.com/leandromoreira/redlock-rb) that adds a gem for easy distribution and perhaps more.
 * [Redlock-py](https://github.com/SPSCommerce/redlock-py) (Python implementation).
+* [Pottery](https://github.com/brainix/pottery#redlock) (Python implementation).
 * [Aioredlock](https://github.com/joanvila/aioredlock) (Asyncio Python implementation).
 * [Redlock-php](https://github.com/ronnylt/redlock-php) (PHP implementation).
 * [PHPRedisMutex](https://github.com/malkusch/lock#phpredismutex) (further PHP implementation)


### PR DESCRIPTION
Hello, folks!

I've been working on my own [set of Pythonic Redis utilities](https://github.com/brainix/pottery), and my library includes a Redlock implementation, so I thought I'd add it to the list. How does it look?

Thanks!
Raj