### PR TITLE
change port to 7002 after redirection

### DIFF
--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -399,7 +399,7 @@ OK
 redis 127.0.0.1:7000> get foo
 -> Redirected to slot [12182] located at 127.0.0.1:7002
 "bar"
-redis 127.0.0.1:7000> get hello
+redis 127.0.0.1:7002> get hello
 -> Redirected to slot [866] located at 127.0.0.1:7000
 "world"
 ```


### PR DESCRIPTION
I believe this port should be `7002` in the example, since it is shown after:

```
redis 127.0.0.1:7000> get foo
-> Redirected to slot [12182] located at 127.0.0.1:7002
"bar"
```