### PR TITLE
Rename Presto SQL to Trino

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -747,11 +747,11 @@
     "authors": ["mjwestcott"]
   },
   {
-    "name": "Presto Redis Connector",
+    "name": "Trino (formerly Presto SQL) Redis Connector",
     "language": "SQL",
-    "url": "https://prestosql.io/docs/current/connector/redis.html",
-    "repository": "https://github.com/prestosql/presto",
-    "description": "Presto Redis connector allows querying Redis data with ANSI SQL, with queries spanning Redis and other services such as Hive, relational databases, Cassandra, Kafka, cloud object storage, or leveraging multiple Redis instances at once",
+    "url": "https://trino.io/docs/current/connector/redis.html",
+    "repository": "https://github.com/trinodb/trino",
+    "description": "Trino Redis connector allows querying Redis data with ANSI SQL, with queries spanning Redis and other services such as Hive, relational databases, Cassandra, Kafka, cloud object storage, or leveraging multiple Redis instances at once",
     "authors": []
   }
 ]


### PR DESCRIPTION
PrestoSQL was rebranded as Trino: https://trino.io/blog/2020/12/27/announcing-trino.html