### PR TITLE
add command deprecation note for GEORADIUS

### DIFF
--- a/commands/brpoplpush.md
+++ b/commands/brpoplpush.md
@@ -5,7 +5,7 @@ When `source` is empty, Redis will block the connection until another client
 pushes to it or until `timeout` is reached.
 A `timeout` of zero can be used to block indefinitely.
 
-As per Redis 6.2.0, BRPOPLPUSH is considered deprecated. Please use `BLMOVE` in
+As per Redis 6.2.0, BRPOPLPUSH is considered deprecated. Please prefer `BLMOVE` in
 new code.
 
 See `RPOPLPUSH` for more information.

--- a/commands/georadius.md
+++ b/commands/georadius.md
@@ -1,5 +1,7 @@
 Return the members of a sorted set populated with geospatial information using `GEOADD`, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
 
+As per Redis 6.2.0, GEORADIUS command family are considered deprecated. Please prefer `GEOSEARCH` and `GEOSEARCHSTORE` in new code.
+
 This manual page also covers the `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO` variants (see the section below for more information).
 
 The common use case for this command is to retrieve geospatial items near a specified point not farther than a given amount of meters (or other units). This allows, for example, to suggest mobile users of an application nearby places.

--- a/commands/georadiusbymember.md
+++ b/commands/georadiusbymember.md
@@ -1,6 +1,8 @@
 This command is exactly like `GEORADIUS` with the sole difference that instead
 of taking, as the center of the area to query, a longitude and latitude value, it takes the name of a member already existing inside the geospatial index represented by the sorted set.
 
+As per Redis 6.2.0, GEORADIUS command family are considered deprecated. Please prefer `GEOSEARCH` and `GEOSEARCHSTORE` in new code.
+
 The position of the specified member is used as the center of the query.
 
 Please check the example below and the `GEORADIUS` documentation for more information about the command and its options.

--- a/commands/geosearch.md
+++ b/commands/geosearch.md
@@ -1,5 +1,7 @@
 Return the members of a sorted set populated with geospatial information using `GEOADD`, which are within the borders of the area specified by a given shape. This command extends the `GEORADIUS` command, so in addition to searching within circular areas, it supports searching within rectangular areas.
 
+This command comes in place of the now deprecated `GEORADIUS` and `GEORADIUSBYMEMBER`.
+
 The query's center point is provided by one of these mandatory options:
 
 * `FROMMEMBER`: Use the position of the given existing `<member>` in the sorted set.

--- a/commands/geosearchstore.md
+++ b/commands/geosearchstore.md
@@ -1,5 +1,7 @@
 This command is like `GEOSEARCH`, but stores the result in destination key.
 
+This command comes in place of the now deprecated `GEORADIUS` and `GEORADIUSBYMEMBER`.
+
 By default, it stores the results in the `destintion` sorted set with their geospatial information.
 
 When using the `STOREDIST` option, the command stores the items in a sorted set populated with their distance from the center of the circle or box, as a floating-point number, in the same unit specified for that shape.

--- a/commands/getset.md
+++ b/commands/getset.md
@@ -15,7 +15,7 @@ GETSET mycounter "0"
 GET mycounter
 ```
 
-As per Redis 6.2, GETSET is considered deprecated. Please use `SET` with `GET` parameter in new code.
+As per Redis 6.2, GETSET is considered deprecated. Please prefer `SET` with `GET` parameter in new code.
 
 @return
 

--- a/commands/hmset.md
+++ b/commands/hmset.md
@@ -3,7 +3,7 @@ Sets the specified fields to their respective values in the hash stored at
 This command overwrites any specified fields already existing in the hash.
 If `key` does not exist, a new key holding a hash is created.
 
-As per Redis 4.0.0, HMSET is considered deprecated. Please use `HSET` in new code.
+As per Redis 4.0.0, HMSET is considered deprecated. Please prefer `HSET` in new code.
 
 @return
 

--- a/commands/rpoplpush.md
+++ b/commands/rpoplpush.md
@@ -13,7 +13,7 @@ If `source` and `destination` are the same, the operation is equivalent to
 removing the last element from the list and pushing it as first element of the
 list, so it can be considered as a list rotation command.
 
-As per Redis 6.2.0, RPOPLPUSH is considered deprecated. Please use `LMOVE` in
+As per Redis 6.2.0, RPOPLPUSH is considered deprecated. Please prefer `LMOVE` in
 new code.
 
 @return


### PR DESCRIPTION
also replace test in existing deprecatoin notes with "prefer", since the
new commands may not be supported by the client libraries.