### PR TITLE
New ZRANGESTORE and ZRANGE new args, deprecate others

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -4067,8 +4067,61 @@
     "since": "5.0.0",
     "group": "sorted_set"
   },
+  "ZRANGESTORE": {
+    "summary": "Store a range of members from sorted set into another key",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements stored into the destination key.",
+    "arguments": [
+      {
+        "name": "dst",
+        "type": "key"
+      },
+      {
+        "name": "src",
+        "type": "key"
+      },
+      {
+        "name": "min",
+        "type": "string"
+      },
+      {
+        "name": "max",
+        "type": "string"
+      },
+      {
+        "name": "sortby",
+        "type": "enum",
+        "enum": [
+          "BYSCORE",
+          "BYLEX"
+        ],
+        "optional": true
+      },
+      {
+        "name": "rev",
+        "type": "enum",
+        "enum": [
+          "REV"
+        ],
+        "optional": true
+      },
+      {
+        "command": "LIMIT",
+        "name": [
+          "offset",
+          "count"
+        ],
+        "type": [
+          "integer",
+          "integer"
+        ],
+        "optional": true
+      }
+    ],
+    "since": "6.2.0",
+    "group": "sorted_set"
+  },
   "ZRANGE": {
-    "summary": "Return a range of members in a sorted set, by index",
+    "summary": "Return a range of members in a sorted set",
     "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.",
     "arguments": [
       {
@@ -4076,12 +4129,41 @@
         "type": "key"
       },
       {
-        "name": "start",
-        "type": "integer"
+        "name": "min",
+        "type": "string"
       },
       {
-        "name": "stop",
-        "type": "integer"
+        "name": "max",
+        "type": "string"
+      },
+      {
+        "name": "sortby",
+        "type": "enum",
+        "enum": [
+          "BYSCORE",
+          "BYLEX"
+        ],
+        "optional": true
+      },
+      {
+        "name": "rev",
+        "type": "enum",
+        "enum": [
+          "REV"
+        ],
+        "optional": true
+      },
+      {
+        "command": "LIMIT",
+        "name": [
+          "offset",
+          "count"
+        ],
+        "type": [
+          "integer",
+          "integer"
+        ],
+        "optional": true
       },
       {
         "name": "withscores",

--- a/commands/zrange.md
+++ b/commands/zrange.md
@@ -2,23 +2,33 @@ Returns the specified range of elements in the sorted set stored at `key`.
 The elements are considered to be ordered from the lowest to the highest score.
 Lexicographical order is used for elements with equal score.
 
-See `ZREVRANGE` when you need the elements ordered from highest to lowest score
-(and descending lexicographical order for elements with equal score).
+As per Redis 6.2.0, this command has the capability to replace `Z[REV]RANGE[BYLEX|BYSCORE]` which are now considered deprecated.
 
-Both `start` and `stop` are zero-based indexes, where `0` is the first element,
-`1` is the next element and so on.
+By default the `min` and `max` arguments represent zero-based indexes, where `0`
+is the first element, `1` is the next element and so on.
 They can also be negative numbers indicating offsets from the end of the sorted
 set, with `-1` being the last element of the sorted set, `-2` the penultimate
-element and so on.
-
-`start` and `stop` are **inclusive ranges**, so for example `ZRANGE myzset 0 1`
+element and so on. in that case
+`min` and `max` are **inclusive ranges**, so for example `ZRANGE myzset 0 1`
 will return both the first and the second element of the sorted set.
 
 Out of range indexes will not produce an error.
-If `start` is larger than the largest index in the sorted set, or `start >
-stop`, an empty list is returned.
-If `stop` is larger than the end of the sorted set Redis will treat it like it
+If `min` is larger than the largest index in the sorted set, or `min > max`, an empty list is returned.
+If `max` is larger than the end of the sorted set Redis will treat it like it
 is the last element of the sorted set.
+
+If a `BYSCORE` argument is given the command behaves like `ZRANGEBYSCORE`, see its documentation for details.
+If a `BYLEX` argument is given the command behaves like `ZRANGEBYLEX`, see its documentation for details.
+
+The optional `REV` argument can be used to have the elements ordered from the highest to the lowest score.
+Descending lexicographical order is used for elements with equal score.
+
+The optional `LIMIT` argument can be used to only get a range of the matching
+elements (similar to _SELECT LIMIT offset, count_ in SQL). A negative `count`
+returns all elements from the `offset`.
+Keep in mind that if `offset` is large, the sorted set needs to be traversed for
+`offset` elements before getting to the elements to return, which can add up to
+O(N) time complexity.
 
 It is possible to pass the `WITHSCORES` option in order to return the scores of
 the elements together with the elements.
@@ -31,6 +41,10 @@ array with (value, score) arrays/tuples).
 
 @array-reply: list of elements in the specified range (optionally with
 their scores, in case the `WITHSCORES` option is given).
+
+@history
+
+* `>= 6.2`: Added the `REV`, `BYSCORE`, `BYLEX` and `LIMIT` options.
 
 @examples
 

--- a/commands/zrange.md
+++ b/commands/zrange.md
@@ -10,7 +10,7 @@ The order of elements is from the lowest to the highest score. Elements with the
 
 The optional `REV` argument reverses the ordering, so elements are ordered from highest to lowest score, and score ties are resolved by reverse lexicographical ordering.
 
-The optional `LIMIT` argument can be used to obtain a subrange from the matching elements (similar to _SELECT LIMIT offset, count_ in SQL). 
+The optional `LIMIT` argument can be used to obtain a sub-range from the matching elements (similar to _SELECT LIMIT offset, count_ in SQL).
 A negative `<count>` returns all elements from the `<offset>`. Keep in mind that if `<offset>` is large, the sorted set needs to be traversed for `<offset>` elements before getting to the elements to return, which can add up to O(N) time complexity.
 
 The optional `WITHSCORES` argument supplements the command's reply with the scores of elements returned. The returned list contains `value1,score1,...,valueN,scoreN` instead of `value1,...,valueN`. Client libraries are free to return a more appropriate data type (suggestion: an array with (value, score) arrays/tuples).
@@ -19,7 +19,7 @@ The optional `WITHSCORES` argument supplements the command's reply with the scor
 
 By default, the command performs an index range query. The `<min>` and `<max>` arguments represent zero-based indexes, where `0` is the first element, `1` is the next element, and so on. These arguments specify an **inclusive range**, so for example, `ZRANGE myzset 0 1` will return both the first and the second element of the sorted set.
 
-The indexes can also be negative numbers indicating offsets from the end of the sorted set, with `-1` being the last element of the sorted set, `-2` the penultimate element, and so on. 
+The indexes can also be negative numbers indicating offsets from the end of the sorted set, with `-1` being the last element of the sorted set, `-2` the penultimate element, and so on.
 
 Out of range indexes do not produce an error.
 
@@ -103,7 +103,7 @@ The following example using `WITHSCORES` shows how the command returns always an
 ZRANGE myzset 0 1 WITHSCORES
 ```
 
-This example shows how to query the sorted set by score, excluding the value `1` and up to inifinity, returning only the second element of the result: 
+This example shows how to query the sorted set by score, excluding the value `1` and up to infinity, returning only the second element of the result:
 
 ```cli
 ZRANGE myzset (1 +inf BYSCORE LIMIT 1 1

--- a/commands/zrangebylex.md
+++ b/commands/zrangebylex.md
@@ -2,6 +2,8 @@ When all the elements in a sorted set are inserted with the same score, in order
 
 If the elements in the sorted set have different scores, the returned elements are unspecified.
 
+As per Redis 6.2.0, ZRANGEBYLEX is considered deprecated. Please prefer `ZRANGE` with `BYLEX` argument in new code.
+
 The elements are considered to be ordered from lower to higher strings as compared byte-by-byte using the `memcmp()` C function. Longer strings are considered greater than shorter strings if the common part is identical.
 
 The optional `LIMIT` argument can be used to only get a range of the matching

--- a/commands/zrangebylex.md
+++ b/commands/zrangebylex.md
@@ -2,9 +2,9 @@ When all the elements in a sorted set are inserted with the same score, in order
 
 If the elements in the sorted set have different scores, the returned elements are unspecified.
 
-As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYLEX` argument in new code.
-
 The elements are considered to be ordered from lower to higher strings as compared byte-by-byte using the `memcmp()` C function. Longer strings are considered greater than shorter strings if the common part is identical.
+
+As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYLEX` argument in new code.
 
 The optional `LIMIT` argument can be used to only get a range of the matching
 elements (similar to _SELECT LIMIT offset, count_ in SQL). A negative `count`

--- a/commands/zrangebyscore.md
+++ b/commands/zrangebyscore.md
@@ -6,6 +6,8 @@ The elements having the same score are returned in lexicographical order (this
 follows from a property of the sorted set implementation in Redis and does not
 involve further computation).
 
+As per Redis 6.2.0, ZRANGEBYSCORE is considered deprecated. Please prefer `ZRANGE` with `BYSCORE` argument in new code.
+
 The optional `LIMIT` argument can be used to only get a range of the matching
 elements (similar to _SELECT LIMIT offset, count_ in SQL). A negative `count`
 returns all elements from the `offset`.

--- a/commands/zrangestore.md
+++ b/commands/zrangestore.md
@@ -1,0 +1,13 @@
+This command is like `ZRANGE`, but stores the result in destination key.
+
+@return
+
+@integer-reply: the number of elements in the resulting sorted set.
+
+@examples
+
+```cli
+ZADD key1 1 "one" 2 "two" 3 "three" 4 "four"
+ZRANGESTORE key2 key1 2 -1
+ZRANGE key2
+```

--- a/commands/zrevrange.md
+++ b/commands/zrevrange.md
@@ -4,6 +4,8 @@ Descending lexicographical order is used for elements with equal score.
 
 Apart from the reversed ordering, `ZREVRANGE` is similar to `ZRANGE`.
 
+As per Redis 6.2.0, ZREVRANGE is considered deprecated. Please prefer `ZRANGE` with `REV` argument in new code.
+
 @return
 
 @array-reply: list of elements in the specified range (optionally with

--- a/commands/zrevrangebylex.md
+++ b/commands/zrevrangebylex.md
@@ -1,8 +1,8 @@
 When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns all the elements in the sorted set at `key` with a value between `max` and `min`.
 
-As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYLEX` and `REV` arguments in new code.
-
 Apart from the reversed ordering, `ZREVRANGEBYLEX` is similar to `ZRANGEBYLEX`.
+
+As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYLEX` and `REV` arguments in new code.
 
 @return
 

--- a/commands/zrevrangebylex.md
+++ b/commands/zrevrangebylex.md
@@ -1,5 +1,7 @@
 When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns all the elements in the sorted set at `key` with a value between `max` and `min`.
 
+As per Redis 6.2.0, ZREVRANGEBYLEX is considered deprecated. Please prefer `ZRANGE` with `BYLEX` and `REV` arguments in new code.
+
 Apart from the reversed ordering, `ZREVRANGEBYLEX` is similar to `ZRANGEBYLEX`.
 
 @return

--- a/commands/zrevrangebyscore.md
+++ b/commands/zrevrangebyscore.md
@@ -6,6 +6,8 @@ elements are considered to be ordered from high to low scores.
 The elements having the same score are returned in reverse lexicographical
 order.
 
+As per Redis 6.2.0, ZREVRANGEBYSCORE is considered deprecated. Please prefer `ZRANGE` with `BYSCORE` and `REV` arguments in new code.
+
 Apart from the reversed ordering, `ZREVRANGEBYSCORE` is similar to
 `ZRANGEBYSCORE`.
 

--- a/commands/zrevrangebyscore.md
+++ b/commands/zrevrangebyscore.md
@@ -6,10 +6,10 @@ elements are considered to be ordered from high to low scores.
 The elements having the same score are returned in reverse lexicographical
 order.
 
-As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYSCORE` and `REV` arguments in new code.
-
 Apart from the reversed ordering, `ZREVRANGEBYSCORE` is similar to
 `ZRANGEBYSCORE`.
+
+As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYSCORE` and `REV` arguments in new code.
 
 @return
 


### PR DESCRIPTION
i'm not very comfortable with how this came out.
documenting all the nuances and instructions of BYSCORE / BYLEX / BYRANK in one page can make it quite complex.
instead i added a note to refer to the documentation of the deprecated commands for details (which sounds like a bad idea).
maybe that's a hint that this change is all wrong?
i.e. there are a lot of details about inclusive / exclusive searches and how the lexicographic ordering works, maybe unifying them into one command is wrong?