### PR TITLE
Fixed consistency issue with history versions

### DIFF
--- a/commands/client-kill.md
+++ b/commands/client-kill.md
@@ -54,8 +54,8 @@ When called with the filter / value format:
 
 @history
 
-* `>=2.8.12`: Added new filter format. 
-* `>=2.8.12`: `ID` option.
-* `>=3.2`: Added `master` type in for `TYPE` option.
-* `>=5`: Replaced `slave` `TYPE` with `replica`. `slave` still supported for backward compatibility.
-* `>=6.2`: `LADDR` option.
+* `>= 2.8.12`: Added new filter format. 
+* `>= 2.8.12`: `ID` option.
+* `>= 3.2`: Added `master` type in for `TYPE` option.
+* `>= 5`: Replaced `slave` `TYPE` with `replica`. `slave` still supported for backward compatibility.
+* `>= 6.2`: `LADDR` option.

--- a/commands/client-list.md
+++ b/commands/client-list.md
@@ -77,6 +77,6 @@ unknown fields).
 
 @history
 
-* `>=2.8.12`: Added unique client `id` field.
-* `>=5.0`: Added optional `TYPE` filter.
-* `>=6.2`: Added `laddr` field and the optional `ID` filter.
+* `>= 2.8.12`: Added unique client `id` field.
+* `>= 5.0`: Added optional `TYPE` filter.
+* `>= 6.2`: Added `laddr` field and the optional `ID` filter.

--- a/commands/monitor.md
+++ b/commands/monitor.md
@@ -91,5 +91,5 @@ flow.
 
 @history
 
-* `>=6.2`: `RESET` can be called to exit monitor mode.
-* `>=6.0`: `AUTH` excluded from the command's output.
+* `>= 6.2`: `RESET` can be called to exit monitor mode.
+* `>= 6.0`: `AUTH` excluded from the command's output.

--- a/commands/subscribe.md
+++ b/commands/subscribe.md
@@ -6,4 +6,4 @@ other commands, except for additional `SUBSCRIBE`, `PSUBSCRIBE`, `UNSUBSCRIBE`,
 
 @history
 
-* `>=6.2`: `RESET` can be called to exit subscribed state.
+* `>= 6.2`: `RESET` can be called to exit subscribed state.

--- a/commands/zadd.md
+++ b/commands/zadd.md
@@ -75,7 +75,7 @@ If the `INCR` option is specified, the return value will be @bulk-string-reply:
   In Redis versions older than 2.4 it was possible to add or update a single
   member per call.
 * `>= 3.0.2`: Added the `XX`, `NX`, `CH` and `INCR` options.
-* `>=6.2`: Added the `GT` and `LT` options.
+* `>= 6.2`: Added the `GT` and `LT` options.
 
 @examples
 


### PR DESCRIPTION
Made @history consistent, since it was brought up in another PR. No need have people copy the wrong format.