### PR TITLE
Adding redis-py-cluster to the list of clients.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -529,6 +529,15 @@
     "recommended": true,
     "active": true
   },
+  
+  {
+    "name": "redis-py-cluster",
+    "language": "Python",
+    "repository": "https://github.com/Grokzen/redis-py-cluster",
+    "description": "Python cluster client for the official redis cluster. Redis 3.0+.",
+    "authors": ["grokzen"],
+    "active": true
+  },
 
   {
     "name": "gxredis",


### PR DESCRIPTION
Adding [redis-py-cluster](https://github.com/Grokzen/redis-py-cluster) to the list of the Python clients. 