### PR TITLE
clients.json: marked node-redis as inactive

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -822,13 +822,13 @@
   },
   
   {
-    "name": "node_redis",
+    "name": "node-redis",
     "language": "Node.js",
-    "repository": "https://github.com/NodeRedis/node_redis",
+    "repository": "https://github.com/NodeRedis/node-redis",
     "description": "Recommended client for node.",
     "authors": ["mranney"],
     "recommended": true,
-    "active": true
+    "active": false
   },
 
   {


### PR DESCRIPTION
With no activity in the repo for a year, it hasn't met the "Clients with some activity in the official repository within the latest six months" criteria for some time.
I kept the `recommended` flag for now, as I'm not sure who decides that and based on what.

Also updated the name from node_redis to node-redis.