### PR TITLE
specify STRALGO LCS sytax more accurately.

### DIFF
--- a/commands/stralgo.md
+++ b/commands/stralgo.md
@@ -11,7 +11,7 @@ the argument must be "LCS", since this is the only implemented one.
 ## LCS algorithm
 
 ```
-STRALGO LCS [KEYS ...] [STRINGS ...] [LEN] [IDX] [MINMATCHLEN <len>] [WITHMATCHLEN]
+STRALGO LCS STRINGS <string_a> <string_b> | KEYS <key_a> <key_b> [LEN] [IDX] [MINMATCHLEN <len>] [WITHMATCHLEN]
 ```
 
 The LCS subcommand implements the longest common subsequence algorithm. Note that this is different than the longest common string algorithm, since matching characters in the string does not need to be contiguous.


### PR DESCRIPTION
currently STRALGO LCS syntax spec is:

```
STRALGO LCS [KEYS ...] [STRINGS ...] [LEN] [IDX] [MINMATCHLEN <len>] [WITHMATCHLEN]
```

which IMHO is not accurate, and might be confusing:

- `KEYS ...`, `STRINGS ...`  seems like the LCS algo can accept arbitary number of KEY or STRING
- ` [KEYS ...] [STRINGS ...]` seems like LCS can accept either `KEYS`, `STRINGS` , or both or neither

I suggest 'the one' used in the source code comment(accually 'the one' also missed LEN option):

```
STRALGO LCS STRINGS <string_a> <string_b> | KEYS <key_a> <key_b> [LEN] [IDX] [MINMATCHLEN <len>] [WITHMATCHLEN] 
```
