### PR TITLE
Fix RESET command misleading typo and add CLIENT KILL LADDR

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -492,6 +492,12 @@
         "optional": true
       },
       {
+        "command": "LADDR",
+        "name": "ip:port",
+        "type": "string",
+        "optional": true
+      },
+      {
         "command": "SKIPME",
         "name": "yes/no",
         "type": "string",

--- a/commands/reset.md
+++ b/commands/reset.md
@@ -7,7 +7,7 @@ following:
 * Discards the current `MULTI` transaction block, if one exists.
 * Unwatches all keys `WATCH`ed by the connection.
 * Disables `CLIENT TRACKING`, if in use.
-* Sets the connection to `READONLY` mode.
+* Sets the connection to `READWRITE` mode.
 * Cancels the connection's `ASKING` mode, if previously set.
 * Sets `CLIENT REPLY` to `ON`.
 * Sets the protocol version to RESP2.


### PR DESCRIPTION
Fix RESET command sets the connection to READWRITE instead of READONLY.
Add LADDR in command CLIENT LIST.