### PR TITLE
Stream command cleanups

### DIFF
--- a/commands/xack.md
+++ b/commands/xack.md
@@ -20,8 +20,10 @@ Redis server.
 
 The command returns the number of messages successfully acknowledged.
 Certain message IDs may no longer be part of the PEL (for example because
-they have been already acknowledge), and XACK will not count them as
+they have already been acknowledged), and XACK will not count them as
 successfully acknowledged.
+
+@examples
 
 ```cli
 XACK mystream mygroup 1526569495631-0

--- a/commands/xack.md
+++ b/commands/xack.md
@@ -1,5 +1,5 @@
 The `XACK` command removes one or multiple messages from the
-*pending entries list* (PEL) of a stream consumer group. A message is pending,
+*Pending Entries List* (PEL) of a stream consumer group. A message is pending,
 and as such stored inside the PEL, when it was delivered to some consumer,
 normally as a side effect of calling `XREADGROUP`, or when a consumer took
 ownership of a message calling `XCLAIM`. The pending message was delivered to

--- a/commands/xautoclaim.md
+++ b/commands/xautoclaim.md
@@ -2,7 +2,7 @@ This command transfers ownership of pending stream entries that match the specif
 but provides a more straightforward way to deal with message delivery failures via `SCAN`-like semantics.
 
 Like `XCLAIM`, the command operates on the stream entries at `<key>` and in the context of the provided `<group>`.
-It transfers ownership to `<consumer>` of messages pending for more than `<min-idle-time>` milliseconds and having an equal or greater ID than `<start>`. 
+It transfers ownership to `<consumer>` of messages pending for more than `<min-idle-time>` milliseconds and having an equal or greater ID than `<start>`.
 
 The optional `<count>` argument, which defaults to 100, is the upper limit of the number of entries that the command attempts to claim.
 Internally, the command begins scanning the consumer group's Pending Entries List (PEL) from `<start>` and filters out entries having an idle time less than or equal to `<min-idle-time>`.
@@ -31,7 +31,7 @@ An array with two elements:
 1. The first element is a stream ID to be used as the `<start>` argument for the next call to `XAUTOCLAIM`
 2. The second element is an array containing all the successfully claimed messages in the same format as `XRANGE`.
 
-Example:
+@examples
 
 ```
 > XAUTOCLAIM mystream mygroup Alice 3600000 0-0 COUNT 25

--- a/commands/xautoclaim.md
+++ b/commands/xautoclaim.md
@@ -5,7 +5,7 @@ Like `XCLAIM`, the command operates on the stream entries at `<key>` and in the 
 It transfers ownership to `<consumer>` of messages pending for more than `<min-idle-time>` milliseconds and having an equal or greater ID than `<start>`. 
 
 The optional `<count>` argument, which defaults to 100, is the upper limit of the number of entries that the command attempts to claim.
-Internally, the command begins scanning the consumer group's PEL from `<start>` and filters out entries having an idle time less than or equal to `<min-idle-time>`.
+Internally, the command begins scanning the consumer group's Pending Entries List (PEL) from `<start>` and filters out entries having an idle time less than or equal to `<min-idle-time>`.
 The maximum number of pending entries that the command scans is the product of multiplying `<count>`'s value by 10 (hard-coded).
 It is possible, therefore, that the number of entries claimed will be less than the specified value.
 

--- a/commands/xclaim.md
+++ b/commands/xclaim.md
@@ -35,7 +35,7 @@ The command returns all the messages successfully claimed, in the same format
 as `XRANGE`. However if the `JUSTID` option was specified, only the message
 IDs are reported, without including the actual message.
 
-Example:
+@examples
 
 ```
 > XCLAIM mystream mygroup Alice 3600000 1526569498055-0

--- a/commands/xclaim.md
+++ b/commands/xclaim.md
@@ -4,7 +4,7 @@ command argument. Normally this is what happens:
 
 1. There is a stream with an associated consumer group.
 2. Some consumer A reads a message via `XREADGROUP` from a stream, in the context of that consumer group.
-3. As a side effect a pending message entry is created in the pending entries list (PEL) of the consumer group: it means the message was delivered to a given consumer, but it was not yet acknowledged via `XACK`.
+3. As a side effect a pending message entry is created in the Pending Entries List (PEL) of the consumer group: it means the message was delivered to a given consumer, but it was not yet acknowledged via `XACK`.
 4. Then suddenly that consumer fails forever.
 5. Other consumers may inspect the list of pending messages, that are stale for quite some time, using the `XPENDING` command. In order to continue processing such messages, they use `XCLAIM` to acquire the ownership of the message and continue. As of Redis 6.2, consumers can use the `XAUTOCLAIM` command to automatically scan and claim stale pending messages.
 

--- a/commands/xgroup.md
+++ b/commands/xgroup.md
@@ -55,8 +55,8 @@ form is used:
     XGROUP DELCONSUMER mystream consumer-group-name myconsumer123
 
 Sometimes it may be useful to remove old consumers since they are no longer
-used. This form returns an @integer-reply with the number of pending messages
-that the consumer had before it was deleted.
+used.
+This form returns an @integer-reply with the number of pending messages that the consumer had before it was deleted.
 
 Finally it possible to set the next message to deliver using the
 `SETID` subcommand. Normally the next ID is set when the consumer is

--- a/commands/xgroup.md
+++ b/commands/xgroup.md
@@ -38,8 +38,8 @@ A consumer group can be destroyed completely by using the following form:
 
 The consumer group will be destroyed even if there are active consumers
 and pending messages, so make sure to call this command only when really
-needed. This form returns an @integer-reply with the number of destroyed
-consumer groups (0 or 1).
+needed.
+This form returns an @integer-reply with the number of destroyed consumer groups (0 or 1).
 
 Consumers in a consumer group are auto-created every time a new consumer
 name is mentioned by some command. They can also be explicitly created

--- a/commands/xgroup.md
+++ b/commands/xgroup.md
@@ -22,8 +22,8 @@ zero as the starting ID for the consumer group:
 
 Of course it is also possible to use any other valid ID. If the specified
 consumer group already exists, the command returns a `-BUSYGROUP` error.
-Otherwise the operation is performed and a @simple-string-reply `OK` is returned. There are no hard
-limits to the number of consumer groups you can associate to a given stream.
+Otherwise, the operation is performed and a @simple-string-reply `OK` is returned.
+There are no hard limits to the number of consumer groups you can associate with a given stream.
 
 If the specified stream doesn't exist when creating a group, an error will be
 returned. You can use the optional `MKSTREAM` subcommand as the last argument

--- a/commands/xgroup.md
+++ b/commands/xgroup.md
@@ -22,7 +22,7 @@ zero as the starting ID for the consumer group:
 
 Of course it is also possible to use any other valid ID. If the specified
 consumer group already exists, the command returns a `-BUSYGROUP` error.
-Otherwise the operation is performed and OK is returned. There are no hard
+Otherwise the operation is performed and a @simple-string-reply `OK` is returned. There are no hard
 limits to the number of consumer groups you can associate to a given stream.
 
 If the specified stream doesn't exist when creating a group, an error will be
@@ -38,7 +38,8 @@ A consumer group can be destroyed completely by using the following form:
 
 The consumer group will be destroyed even if there are active consumers
 and pending messages, so make sure to call this command only when really
-needed.
+needed. This form returns an @integer-reply with the number of destroyed
+consumer groups (0 or 1).
 
 Consumers in a consumer group are auto-created every time a new consumer
 name is mentioned by some command. They can also be explicitly created
@@ -46,14 +47,16 @@ by using the following form:
 
     XGROUP CREATECONSUMER mystream consumer-group-name myconsumer123
 
+This form returns an @integer-reply with the number of created consumers (0 or 1).
+
 To just remove a given consumer from a consumer group, the following
 form is used:
 
     XGROUP DELCONSUMER mystream consumer-group-name myconsumer123
 
 Sometimes it may be useful to remove old consumers since they are no longer
-used. This form returns the number of pending messages that the consumer
-had before it was deleted.
+used. This form returns an @integer-reply with the number of pending messages
+that the consumer had before it was deleted.
 
 Finally it possible to set the next message to deliver using the
 `SETID` subcommand. Normally the next ID is set when the consumer is
@@ -64,6 +67,8 @@ to re-process all the messages in a stream, you may want to set its next
 ID to 0:
 
     XGROUP SETID mystream consumer-group-name 0
+
+This form returns a @simple-string-reply `OK` or an error.
 
 Finally to get some help if you don't remember the syntax, use the
 HELP subcommand:

--- a/commands/xinfo.md
+++ b/commands/xinfo.md
@@ -39,7 +39,7 @@ sense about what is the stream content.
 * `XINFO STREAM <key> FULL [COUNT <count>]`
 
 In this form the command returns the entire state of the stream, including
-entries, groups, consumers and PELs. This form is available since Redis 6.0.
+entries, groups, consumers and Pending Entries Lists (PELs). This form is available since Redis 6.0.
 
 ```
 > XADD mystream * foo bar

--- a/commands/xinfo.md
+++ b/commands/xinfo.md
@@ -39,7 +39,8 @@ sense about what is the stream content.
 * `XINFO STREAM <key> FULL [COUNT <count>]`
 
 In this form the command returns the entire state of the stream, including
-entries, groups, consumers and Pending Entries Lists (PELs). This form is available since Redis 6.0.
+entries, groups, consumers and Pending Entries Lists (PELs).
+This form is available since Redis 6.0.
 
 ```
 > XADD mystream * foo bar

--- a/commands/xpending.md
+++ b/commands/xpending.md
@@ -63,7 +63,7 @@ at least one pending message, and the number of pending messages it has.
 ## Extended form of XPENDING
 
 The summary provides a good overview, but sometimes we are interested in the
-details. In order to see all the pending messages with more associated 
+details. In order to see all the pending messages with more associated
 information we need to also pass a range of IDs, in a similar way we do it with
 `XRANGE`, and a non optional *count* argument, to limit the number
 of messages returned per call:
@@ -127,6 +127,8 @@ The `XPENDING` command allows iterating over the pending entries just like
 prefixing the ID of the last-read pending entry with the `(` character that
 denotes an open (exclusive) range, and proving it to the subsequent call to the
 command.
+
+@return
 
 @array-reply, specifically:
 

--- a/commands/xpending.md
+++ b/commands/xpending.md
@@ -2,7 +2,7 @@ Fetching data from a stream via a consumer group, and not acknowledging
 such data, has the effect of creating *pending entries*. This is
 well explained in the `XREADGROUP` command, and even better in our
 [introduction to Redis Streams](/topics/streams-intro). The `XACK` command
-will immediately remove the pending entry from the Pending Entry List (PEL)
+will immediately remove the pending entry from the Pending Entries List (PEL)
 since once a message is successfully processed, there is no longer need
 for the consumer group to track it and to remember the current owner
 of the message.

--- a/commands/xreadgroup.md
+++ b/commands/xreadgroup.md
@@ -62,7 +62,7 @@ are no differences in this regard.
 
 Two things:
 
-1. If the message was never delivered to anyone, that is, if we are talking about a new message, then a PEL (Pending Entry List) is created.
+1. If the message was never delivered to anyone, that is, if we are talking about a new message, then a PEL (Pending Entries List) is created.
 2. If instead the message was already delivered to this consumer, and it is just re-fetching the same message again, then the *last delivery counter* is updated to the current time, and the *number of deliveries* is incremented by one. You can access those message properties using the `XPENDING` command.
 
 ## Usage example

--- a/commands/xreadgroup.md
+++ b/commands/xreadgroup.md
@@ -102,6 +102,8 @@ consumers that are processing new things.
 
 To see how the command actually replies, please check the `XREAD` command page.
 
+@return
+
 @array-reply, specifically:
 
 The command returns an array of results: each element of the returned


### PR DESCRIPTION
Corrected some minor issues which might help others when going through the descriptions of the stream commands:
- Source code only mentions `pending entries list` which is now used in docs.
- Use of `@examples` and `@return`
- State the different return types for the different forms of `XGROUP` 