### PR TITLE
Fix wrong order of geospatial tuple

### DIFF
--- a/commands/geoadd.md
+++ b/commands/geoadd.md
@@ -1,4 +1,4 @@
-Adds the specified geospatial items (latitude, longitude, name) to the specified key. Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the `GEOSEARCH` command.
+Adds the specified geospatial items (longitude, latitude, name) to the specified key. Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the `GEOSEARCH` command.
 
 The command takes arguments in the standard format x,y so the longitude must be specified before the latitude. There are limits to the coordinates that can be indexed: areas very near to the poles are not indexable.
 


### PR DESCRIPTION
The prompt of command GEOADD in redis-cli (6.2.1) is:
> GEOADD key [NX|XX] [CH] longitude latitude member [longitude latitude member ...]