### PR TITLE
Remove cli tag from XACK

### DIFF
--- a/commands/xack.md
+++ b/commands/xack.md
@@ -25,6 +25,7 @@ successfully acknowledged.
 
 @examples
 
-```cli
-XACK mystream mygroup 1526569495631-0
+```
+redis> XACK mystream mygroup 1526569495631-0
+(integer) 1
 ```


### PR DESCRIPTION
redis.io page was showing interactive cli for XACK which is blocked and through an error in the response. I removed the cli tag and fixed the example to show how it would look to the user