### PR TITLE
Remove WITHCOORD, WITHDIST and WITHHASH

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1857,30 +1857,6 @@
         "optional": true
       },
       {
-        "name": "withcoord",
-        "type": "enum",
-        "enum": [
-          "WITHCOORD"
-        ],
-        "optional": true
-      },
-      {
-        "name": "withdist",
-        "type": "enum",
-        "enum": [
-          "WITHDIST"
-        ],
-        "optional": true
-      },
-      {
-        "name": "withhash",
-        "type": "enum",
-        "enum": [
-          "WITHHASH"
-        ],
-        "optional": true
-      },
-      {
         "name": "storedist",
         "type": "enum",
         "enum": [


### PR DESCRIPTION
WITHCOORD, WITHDIST and WITHHASH are not meant to be supported since this command a STORE command, which doesn't support those args.

Fixes issue #8864