### PR TITLE
fix modules-cluster api description for RedisModule_GetClusterNodesList

### DIFF
--- a/topics/modules-api-ref.md
+++ b/topics/modules-api-ref.md
@@ -3156,7 +3156,7 @@ known cluster node, `REDISMODULE_ERR` is returned.
     char **RedisModule_GetClusterNodesList(RedisModuleCtx *ctx, size_t *numnodes);
 
 Return an array of string pointers, each string pointer points to a cluster
-node ID of exactly `REDISMODULE_NODE_ID_SIZE` bytes (without any null term).
+node ID of exactly `REDISMODULE_NODE_ID_LEN` bytes (without any null term).
 The number of returned node IDs is stored into `*numnodes`.
 However if this function is called by a module not running an a Redis
 instance with Redis Cluster enabled, NULL is returned instead.
@@ -3172,7 +3172,7 @@ Example:
     size_t count, j;
     char **ids = RedisModule_GetClusterNodesList(ctx,&count);
     for (j = 0; j < count; j++) {
-        RedisModule_Log("notice","Node %.*s",
+        RedisModule_Log(ctx,"notice","Node %.*s",
             REDISMODULE_NODE_ID_LEN,ids[j]);
     }
     RedisModule_FreeClusterNodesList(ids);


### PR DESCRIPTION
* replace incorrect `REDISMODULE_NODE_ID_SIZE` with the correct `REDISMODULE_NODE_ID_LEN` in the cluster api reference for modules.
* fix the call to `RedisModule_Log()` with the correct arguments in the example.