### PR TITLE
Added redis-client (Bash): https://github.com/SomajitDey/redis-client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1396,8 +1396,7 @@
     "language": "Bash",
     "repository": "https://github.com/crypt1d/redi.sh",
     "description": "Simple, Bash-based, Redis client to store your script's variables",
-    "authors": ["nkrzalic"],
-    "active": true
+    "authors": ["nkrzalic"]
   },
 
   {
@@ -1930,6 +1929,14 @@
     "repository": "https://github.com/2881099/FreeRedis",
     "description": "This .NET client supports redis6.0+, cluster, sentinel, pipeline, And simple api.",
     "authors": [],
+    "active": true
+  },
+  
+  {
+    "name": "redis-client",
+    "language": "Bash",
+    "repository": "https://github.com/SomajitDey/redis-client",
+    "description": "extensible client library for Bash scripting or command-line + connection pooling + redis-cli",
     "active": true
   }
 ]


### PR DESCRIPTION
The only existing Bash client featured in https://redis.io/clients#bash, viz. [Redi.sh](https://github.com/crypt1d/redi.sh), is very limited in scope and not very extensible. Although written in Bash, Redi.sh depends unnecessarily on various Unix tools rather than using Bash native functionalities mostly.

The present [client](https://github.com/SomajitDey/redis-client), on the contrary, is written from scratch with a strong focus on using Bash functionalities as much as possible. This adds to its performance and portability. It is also extensible, and currently has full support for any Redis command execution in the request-response mode.  Support for pipelining and push protocol would be added in near future.

The client library also supports creating a Redis session and keeping it alive, instead of creating a new session for every command execution - a feature using which _connection pools_ may be implemented in future. 

Using the client library, a portable Redis command-line-interface (CLI or console) has also been implemented.