### PR TITLE
API documentation of EXPIRETIME and PEXPIRETIME commands

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2877,7 +2877,7 @@
     "group": "generic"
   },
   "PEXPIRETIME": {
-    "summary": "Get the expiration UNIX timestamp for a key in milliseconds",
+    "summary": "Get the expiration Unix timestamp for a key in milliseconds",
     "complexity": "O(1)",
     "arguments": [
       {

--- a/commands.json
+++ b/commands.json
@@ -1244,6 +1244,18 @@
     "since": "1.2.0",
     "group": "generic"
   },
+  "EXPIRETIME": {
+    "summary": "Get the expiration UNIX timestamp for a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      }
+    ],
+    "since": "7.0.0",
+    "group": "generic"
+  },
   "FAILOVER": {
     "summary": "Start a coordinated failover between this server and one of its replicas.",
     "arguments": [
@@ -2862,6 +2874,18 @@
       }
     ],
     "since": "2.6.0",
+    "group": "generic"
+  },
+  "PEXPIRETIME": {
+    "summary": "Get the expiration UNIX timestamp for a key in milliseconds",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      }
+    ],
+    "since": "7.0.0",
     "group": "generic"
   },
   "PFADD": {

--- a/commands.json
+++ b/commands.json
@@ -1245,7 +1245,7 @@
     "group": "generic"
   },
   "EXPIRETIME": {
-    "summary": "Get the expiration UNIX timestamp for a key",
+    "summary": "Get the expiration Unix timestamp for a key",
     "complexity": "O(1)",
     "arguments": [
       {

--- a/commands/expiretime.md
+++ b/commands/expiretime.md
@@ -1,4 +1,4 @@
-Returns the absolute Unix timestamp(since January 1, 1970) in seconds at which the given key will expire.
+Returns the absolute Unix timestamp (since January 1, 1970) in seconds at which the given key will expire.
 
 See also the `PEXPIRETIME` command that returns the same information with milliseconds resolution.
 
@@ -15,4 +15,3 @@ SET mykey "Hello"
 EXPIREAT mykey 33177117420
 EXPIRETIME mykey
 ```
-

--- a/commands/expiretime.md
+++ b/commands/expiretime.md
@@ -5,7 +5,7 @@ See also the `PEXPIRETIME` command that returns the same information with millis
 @return
 
 @integer-reply: Expiration UNIX timestamp in seconds, or a negative value in order to signal an error (see the description below).
-* The command returns `-1` if the key exists but has no associated expire.
+* The command returns `-1` if the key exists but has no associated expiration time.
 * The command returns `-2` if the key does not exist.
 
 @examples

--- a/commands/expiretime.md
+++ b/commands/expiretime.md
@@ -1,0 +1,18 @@
+Returns the absolute Unix timestamp(since January 1, 1970) in seconds at which the given key will expire.
+
+See also the `PEXPIRETIME` command that returns the same information with milliseconds resolution.
+
+@return
+
+@integer-reply: Expiration UNIX timestamp in seconds, or a negative value in order to signal an error (see the description below).
+* The command returns `-1` if the key exists but has no associated expire.
+* The command returns `-2` if the key does not exist.
+
+@examples
+
+```cli
+SET mykey "Hello"
+EXPIREAT mykey 33177117420
+EXPIRETIME mykey
+```
+

--- a/commands/expiretime.md
+++ b/commands/expiretime.md
@@ -4,7 +4,7 @@ See also the `PEXPIRETIME` command that returns the same information with millis
 
 @return
 
-@integer-reply: Expiration UNIX timestamp in seconds, or a negative value in order to signal an error (see the description below).
+@integer-reply: Expiration Unix timestamp in seconds, or a negative value in order to signal an error (see the description below).
 * The command returns `-1` if the key exists but has no associated expiration time.
 * The command returns `-2` if the key does not exist.
 

--- a/commands/expiretime.md
+++ b/commands/expiretime.md
@@ -1,6 +1,6 @@
 Returns the absolute Unix timestamp (since January 1, 1970) in seconds at which the given key will expire.
 
-See also the `PEXPIRETIME` command that returns the same information with milliseconds resolution.
+See also the `PEXPIRETIME` command which returns the same information with milliseconds resolution.
 
 @return
 

--- a/commands/pexpiretime.md
+++ b/commands/pexpiretime.md
@@ -2,7 +2,7 @@
 
 @return
 
-@integer-reply: Expiration UNIX timestamp in milliseconds, or a negative value in order to signal an error (see the description below).
+@integer-reply: Expiration Unix timestamp in milliseconds, or a negative value in order to signal an error (see the description below).
 * The command returns `-1` if the key exists but has no associated expiration time.
 * The command returns `-2` if the key does not exist.
 

--- a/commands/pexpiretime.md
+++ b/commands/pexpiretime.md
@@ -3,7 +3,7 @@
 @return
 
 @integer-reply: Expiration UNIX timestamp in milliseconds, or a negative value in order to signal an error (see the description below).
-* The command returns `-1` if the key exists but has no associated expire.
+* The command returns `-1` if the key exists but has no associated expiration time.
 * The command returns `-2` if the key does not exist.
 
 @examples
@@ -13,4 +13,3 @@ SET mykey "Hello"
 PEXPIREAT mykey 33177117420000
 PEXPIRETIME mykey
 ```
-

--- a/commands/pexpiretime.md
+++ b/commands/pexpiretime.md
@@ -1,0 +1,16 @@
+`PEXPIRETIME` has the same semantic as `EXPIRETIME`, but returns the absolute Unix expiration timestamp in milliseconds instead of seconds.
+
+@return
+
+@integer-reply: Expiration UNIX timestamp in milliseconds, or a negative value in order to signal an error (see the description below).
+* The command returns `-1` if the key exists but has no associated expire.
+* The command returns `-2` if the key does not exist.
+
+@examples
+
+```cli
+SET mykey "Hello"
+PEXPIREAT mykey 33177117420000
+PEXPIRETIME mykey
+```
+


### PR DESCRIPTION
Add API documentation for `EXPIRETIME` and `PEXPIRETIME` commands introduced in this PR: https://github.com/redis/redis/pull/8474

