### PR TITLE
Add `Jedis.jl` to clients.json as a new Julia client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1426,6 +1426,15 @@
     "authors": ["jkaye2012"],
     "active": true
   },
+  
+  {
+    "name": "Jedis.jl",
+    "language": "Julia",
+    "repository": "https://github.com/captchanjack/Jedis.jl",
+    "description": "A lightweight Redis client, implemented in Julia.",
+    "authors": ["captchanjack"],
+    "active": true
+  },
 
   {
     "name": "Redis::Cluster",


### PR DESCRIPTION
Hello redis-doc admins!

I have developed a new Redis client in Julia and would like to add it the list of available Redis clients.

`Jedis.jl` is a a registered packaged, it can be found [here](https://github.com/JuliaRegistries/General/tree/master/J/Jedis) on the Julia general registry. Documentation for the client interface can be found [here](https://captchanjack.github.io/Jedis.jl/).

Let me know if there is anything needed to get this PR in!

Cheers,
Jack