### PR TITLE
Adding ecredis - Erlang Redis Cluster client.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -76,6 +76,14 @@
     "description": "Wrapper around eredis providing process pools and consistent hashing.",
     "authors": ["jeremyong"]
   },
+  {
+    "name": "ecredis",
+    "language": "Erlang",
+    "repository": "https://github.com/HalloAppInc/ecredis",
+    "description": "Redis Cluster client that allows for connections to multiple clusters. Queries are send directly to eredis clients allowing for large throughput.",
+    "authors": ["HalloAppInc"]
+  },
+
 
   {
     "name": "exredis",


### PR DESCRIPTION
Adding a new redis cluster client in erlang.

Some key features
* uses eredis as underlying implementation
* allows connections to multiple clusters at the same time
* queries don't get handled on the cluster-gen-server process they get directed to right eredis client.