### PR TITLE
Address documentation typo on parallel iterations

### DIFF
--- a/commands/scan.md
+++ b/commands/scan.md
@@ -165,7 +165,7 @@ It is important to note that the **TYPE** filter is also applied after elements 
 
 ## Multiple parallel iterations
 
-It is possible for an infinite number of clients to iterate the same collection at the same time, as the full state of the iterator is in the cursor, that is obtained and returned to the client at every call. Server side no state is taken at all.
+It is possible for an infinite number of clients to iterate the same collection at the same time, as the full state of the iterator is in the cursor, that is obtained and returned to the client at every call. No server side state is taken at all.
 
 ## Terminating iterations in the middle
 


### PR DESCRIPTION
Small correction on the docs to improve understanding and legibility.