### PR TITLE
Add info metrics about redis#9031

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -233,9 +233,8 @@ Here is the meaning of all fields in the **stats** section:
 *   `expired_time_cap_reached_count`: The count of times that active expiry cycles have stopped early
 *   `expire_cycle_cpu_milliseconds`: The cumulative amount of time spend on active expiry cycles
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit
-*   `total_eviction_exceeded_time`:  Total time used memory is greater than `maxmemory`
-     since server startup, in milliseconds
-* `current_eviction_exceeded_time`: The number of milliseconds since `used_memory` grew above `maxmemory`.
+*   `total_eviction_exceeded_time`:  Total time `used_memory` was greater than `maxmemory` since server startup, in milliseconds
+*   `current_eviction_exceeded_time`: The time passed since `used_memory` last grew above `maxmemory`, in milliseconds
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary
 *   `pubsub_channels`: Global number of pub/sub channels with client

--- a/commands/info.md
+++ b/commands/info.md
@@ -234,7 +234,7 @@ Here is the meaning of all fields in the **stats** section:
 *   `expire_cycle_cpu_milliseconds`: The cumulative amount of time spend on active expiry cycles
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit
 *   `total_eviction_exceeded_time`:  Total time used memory is greater than `maxmemory`
-     since server startup, unit is `ms`
+     since server startup, in milliseconds
 *   `current_eviction_exceeded_time`: How much time currently used memory is greater than `maxmemory`,
      if used memory is below `maxmemory`, this metric is reset to 0, unit is `ms`
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary

--- a/commands/info.md
+++ b/commands/info.md
@@ -234,7 +234,7 @@ Here is the meaning of all fields in the **stats** section:
 *   `expire_cycle_cpu_milliseconds`: The cumulative amount of time spend on active expiry cycles
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit
 *   `total_eviction_exceeded_time`:  Total time `used_memory` was greater than `maxmemory` since server startup, in milliseconds
-*   `current_eviction_exceeded_time`: The time passed since `used_memory` last grew above `maxmemory`, in milliseconds
+*   `current_eviction_exceeded_time`: The time passed since `used_memory` last rose above `maxmemory`, in milliseconds
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary
 *   `pubsub_channels`: Global number of pub/sub channels with client

--- a/commands/info.md
+++ b/commands/info.md
@@ -233,6 +233,10 @@ Here is the meaning of all fields in the **stats** section:
 *   `expired_time_cap_reached_count`: The count of times that active expiry cycles have stopped early
 *   `expire_cycle_cpu_milliseconds`: The cumulative amount of time spend on active expiry cycles
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit
+*   `total_eviction_exceeded_time`:  Total time used memory is greater than `maxmemory`
+     since server startup, unit is `ms`
+*   `current_eviction_exceeded_time`: How much time currently used memory is greater than `maxmemory`,
+     if used memory is below `maxmemory`, this metric is reset to 0, unit is `ms`
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary
 *   `pubsub_channels`: Global number of pub/sub channels with client

--- a/commands/info.md
+++ b/commands/info.md
@@ -235,7 +235,7 @@ Here is the meaning of all fields in the **stats** section:
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit
 *   `total_eviction_exceeded_time`:  Total time used memory is greater than `maxmemory`
      since server startup, in milliseconds
-*   `current_eviction_exceeded_time`: How much time currently used memory is greater than `maxmemory`,
+*   `current_eviction_exceeded_time`: Duration currently used memory is greater than `maxmemory`,
      if used memory is below `maxmemory`, this metric is reset to 0, unit is `ms`
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary

--- a/commands/info.md
+++ b/commands/info.md
@@ -236,7 +236,7 @@ Here is the meaning of all fields in the **stats** section:
 *   `total_eviction_exceeded_time`:  Total time used memory is greater than `maxmemory`
      since server startup, in milliseconds
 *   `current_eviction_exceeded_time`: Duration currently used memory is greater than `maxmemory`,
-     if used memory is below `maxmemory` this metric is reset to 0, in milliseocnds
+     if used memory is below `maxmemory` this metric is reset to 0, in milliseconds
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary
 *   `pubsub_channels`: Global number of pub/sub channels with client

--- a/commands/info.md
+++ b/commands/info.md
@@ -235,8 +235,7 @@ Here is the meaning of all fields in the **stats** section:
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit
 *   `total_eviction_exceeded_time`:  Total time used memory is greater than `maxmemory`
      since server startup, in milliseconds
-*   `current_eviction_exceeded_time`: Duration currently used memory is greater than `maxmemory`,
-     if used memory is below `maxmemory` this metric is reset to 0, in milliseconds
+* `current_eviction_exceeded_time`: The number of milliseconds since `used_memory` grew above `maxmemory`.
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary
 *   `pubsub_channels`: Global number of pub/sub channels with client

--- a/commands/info.md
+++ b/commands/info.md
@@ -236,7 +236,7 @@ Here is the meaning of all fields in the **stats** section:
 *   `total_eviction_exceeded_time`:  Total time used memory is greater than `maxmemory`
      since server startup, in milliseconds
 *   `current_eviction_exceeded_time`: Duration currently used memory is greater than `maxmemory`,
-     if used memory is below `maxmemory`, this metric is reset to 0, unit is `ms`
+     if used memory is below `maxmemory` this metric is reset to 0, in milliseocnds
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary
 *   `pubsub_channels`: Global number of pub/sub channels with client


### PR DESCRIPTION
Add info metrics total_eviction_exceeded_time and
current_eviction_exceeded_time. See
https://github.com/redis/redis/pull/9031.
