### PR TITLE
INFO details about fragmentation

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -126,17 +126,17 @@ Here is the meaning of all fields in the **memory** section:
     Note that this doesn't only includes fragmentation, but also other process overheads (see the `allocator_*` metrics), and also overheads like code, shared libraries, stack, etc.
 *   `mem_fragmentation_bytes`: Delta between `used_memory_rss` and `used_memory`
     Note that when the total fragmentation bytes is low (few megabytes), a high ratio (e.g. 1.5 and above) is not an indication of an issue.
-*   `allocator_frag_ratio:`: Ratio between `allocator_allocated` and `allocator_active`. This is the true (external) fragmentation metric (not `mem_fragmentation_ratio`)
-*   `allocator_frag_bytes` Delta between `allocator_allocated` and `allocator_active`. See note about `mem_fragmentation_bytes`.
-*   `allocator_rss_ratio`: Ratio between `allocator_active` and `allocator_resident`. This usually indicates pages that the allocator can and probably will soon release back to the OS.
-*   `allocator_rss_bytes`: Delta between `allocator_active` and `allocator_resident`. 
-*   `rss_overhead_ratio`: Ratio between `allocator_resident` and `used_memory_rss` (the process RSS). This includes RSS overheads that are not allocator or heap related.
-*   `rss_overhead_bytes`: Delta between `allocator_resident` and `used_memory_rss` (the process RSS).
+*   `allocator_frag_ratio:`: Ratio between `allocator_active` and `allocator_allocated`. This is the true (external) fragmentation metric (not `mem_fragmentation_ratio`)
+*   `allocator_frag_bytes` Delta between `allocator_active` and `allocator_allocated`. See note about `mem_fragmentation_bytes`.
+*   `allocator_rss_ratio`: Ratio between `allocator_resident` and `allocator_active`. This usually indicates pages that the allocator can and probably will soon release back to the OS.
+*   `allocator_rss_bytes`: Delta between `allocator_resident` and `allocator_active`. 
+*   `rss_overhead_ratio`: Ratio between `used_memory_rss` (the process RSS) and `allocator_resident`. This includes RSS overheads that are not allocator or heap related.
+*   `rss_overhead_bytes`: Delta between `used_memory_rss` (the process RSS) and `allocator_resident`.
 *   `allocator_allocated`: Total bytes allocated form the allocator, including internal-fragmentation. Normally the same as `used_memory`.
 *   `allocator_active`: Total bytes in the allocator active pages, this includes external-fragmentation.
 *   `allocator_resident`: Total bytes resident (RSS) in the allocator, this includes pages that can be released to the OS (by `MEMORY PURGE`, or just waiting)
 *   `mem_allocator`: Memory allocator, chosen at compile time
-*   `active_defrag_running`: When `activedefrag` is enabled, this indicates if active if is active, and the CPU percentage it intends to utilize
+*   `active_defrag_running`: When `activedefrag` is enabled, this indicates whether active defrag is active, and the CPU percentage it intends to utilize
 *   `lazyfree_pending_objects`: The number of objects waiting to be freed (as a
      result of calling `UNLINK`, or `FLUSHDB` and `FLUSHALL` with the **ASYNC**
      option)

--- a/commands/info.md
+++ b/commands/info.md
@@ -123,7 +123,7 @@ Here is the meaning of all fields in the **memory** section:
 *   `maxmemory_policy`: The value of the `maxmemory-policy` configuration
      directive
 *   `mem_fragmentation_ratio`: Ratio between `used_memory_rss` and `used_memory`.
-    Note that this doesn't only includes fragmentation, but also other process overheads (see the `allocator_*` metrics), and also overheads like code, shared libraies, stack, etc.
+    Note that this doesn't only includes fragmentation, but also other process overheads (see the `allocator_*` metrics), and also overheads like code, shared libraries, stack, etc.
 *   `mem_fragmentation_bytes`: Delta between `used_memory_rss` and `used_memory`
     Note that when the total fragmentation bytes is low (few megabytes), a high ratio (e.g. 1.5 and above) is not an indication of an issue.
 *   `allocator_frag_ratio:`: Ratio between `allocator_allocated` and `allocator_active`. This is the true (external) fragmentation metric (not `mem_fragmentation_ratio`)
@@ -134,7 +134,7 @@ Here is the meaning of all fields in the **memory** section:
 *   `rss_overhead_bytes`: Delta between `allocator_resident` and `used_memory_rss` (the process RSS).
 *   `allocator_allocated`: Total bytes allocated form the allocator, including internal-fragmentation. Normally the same as `used_memory`.
 *   `allocator_active`: Total bytes in the allocator active pages, this includes external-fragmentation.
-*   `allocator_resident`: Total bytes redident (RSS) in the allocator, this includes pages that can be released to the OS (by `MEMORY PURGE`, or just waiting)
+*   `allocator_resident`: Total bytes resident (RSS) in the allocator, this includes pages that can be released to the OS (by `MEMORY PURGE`, or just waiting)
 *   `mem_allocator`: Memory allocator, chosen at compile time
 *   `active_defrag_running`: When `activedefrag` is enabled, this indicates if active if is active, and the CPU percentage it intends to utilize
 *   `lazyfree_pending_objects`: The number of objects waiting to be freed (as a

--- a/commands/info.md
+++ b/commands/info.md
@@ -136,7 +136,7 @@ Here is the meaning of all fields in the **memory** section:
 *   `allocator_active`: Total bytes in the allocator active pages, this includes external-fragmentation.
 *   `allocator_resident`: Total bytes resident (RSS) in the allocator, this includes pages that can be released to the OS (by `MEMORY PURGE`, or just waiting)
 *   `mem_allocator`: Memory allocator, chosen at compile time
-*   `active_defrag_running`: When `activedefrag` is enabled, this indicates whether active defrag is active, and the CPU percentage it intends to utilize
+*   `active_defrag_running`: When `activedefrag` is enabled, this indicates whether defragmentation is currently active, and the CPU percentage it intends to utilize
 *   `lazyfree_pending_objects`: The number of objects waiting to be freed (as a
      result of calling `UNLINK`, or `FLUSHDB` and `FLUSHALL` with the **ASYNC**
      option)

--- a/commands/info.md
+++ b/commands/info.md
@@ -122,18 +122,29 @@ Here is the meaning of all fields in the **memory** section:
 *   `maxmemory_human`: Human readable representation of previous value
 *   `maxmemory_policy`: The value of the `maxmemory-policy` configuration
      directive
-*   `mem_fragmentation_ratio`: Ratio between `used_memory_rss` and `used_memory`
+*   `mem_fragmentation_ratio`: Ratio between `used_memory_rss` and `used_memory`.
+    Note that this doesn't only includes fragmentation, but also other process overheads (see the `allocator_*` metrics), and also overheads like code, shared libraies, stack, etc.
+*   `mem_fragmentation_bytes`: Delta between `used_memory_rss` and `used_memory`
+    Note that when the total fragmentation bytes is low (few megabytes), a high ratio (e.g. 1.5 and above) is not an indication of an issue.
+*   `allocator_frag_ratio:`: Ratio between `allocator_allocated` and `allocator_active`. This is the true (external) fragmentation metric (not `mem_fragmentation_ratio`)
+*   `allocator_frag_bytes` Delta between `allocator_allocated` and `allocator_active`. See note about `mem_fragmentation_bytes`.
+*   `allocator_rss_ratio`: Ratio between `allocator_active` and `allocator_resident`. This usually indicates pages that the allocator can and probably will soon release back to the OS.
+*   `allocator_rss_bytes`: Delta between `allocator_active` and `allocator_resident`. 
+*   `rss_overhead_ratio`: Ratio between `allocator_resident` and `used_memory_rss` (the process RSS). This includes RSS overheads that are not allocator or heap related.
+*   `rss_overhead_bytes`: Delta between `allocator_resident` and `used_memory_rss` (the process RSS).
+*   `allocator_allocated`: Total bytes allocated form the allocator, including internal-fragmentation. Normally the same as `used_memory`.
+*   `allocator_active`: Total bytes in the allocator active pages, this includes external-fragmentation.
+*   `allocator_resident`: Total bytes redident (RSS) in the allocator, this includes pages that can be released to the OS (by `MEMORY PURGE`, or just waiting)
 *   `mem_allocator`: Memory allocator, chosen at compile time
-*   `active_defrag_running`: Flag indicating if active defragmentation is active
+*   `active_defrag_running`: When `activedefrag` is enabled, this indicates if active if is active, and the CPU percentage it intends to utilize
 *   `lazyfree_pending_objects`: The number of objects waiting to be freed (as a
      result of calling `UNLINK`, or `FLUSHDB` and `FLUSHALL` with the **ASYNC**
      option)
 
 Ideally, the `used_memory_rss` value should be only slightly higher than
 `used_memory`.
-When rss >> used, a large difference means there is memory fragmentation
-(internal or external), which can be evaluated by checking
-`mem_fragmentation_ratio`.
+When rss >> used, a large difference may mean there is (external) memory fragmentation, which can be evaluated by checking
+`allocator_frag_ratio`, `allocator_frag_bytes`.
 When used >> rss, it means part of Redis memory has been swapped off by the
 operating system: expect some significant latencies.
 

--- a/commands/info.md
+++ b/commands/info.md
@@ -124,19 +124,19 @@ Here is the meaning of all fields in the **memory** section:
      directive
 *   `mem_fragmentation_ratio`: Ratio between `used_memory_rss` and `used_memory`.
     Note that this doesn't only includes fragmentation, but also other process overheads (see the `allocator_*` metrics), and also overheads like code, shared libraries, stack, etc.
-*   `mem_fragmentation_bytes`: Delta between `used_memory_rss` and `used_memory`
+*   `mem_fragmentation_bytes`: Delta between `used_memory_rss` and `used_memory`.
     Note that when the total fragmentation bytes is low (few megabytes), a high ratio (e.g. 1.5 and above) is not an indication of an issue.
-*   `allocator_frag_ratio:`: Ratio between `allocator_active` and `allocator_allocated`. This is the true (external) fragmentation metric (not `mem_fragmentation_ratio`)
+*   `allocator_frag_ratio:`: Ratio between `allocator_active` and `allocator_allocated`. This is the true (external) fragmentation metric (not `mem_fragmentation_ratio`).
 *   `allocator_frag_bytes` Delta between `allocator_active` and `allocator_allocated`. See note about `mem_fragmentation_bytes`.
 *   `allocator_rss_ratio`: Ratio between `allocator_resident` and `allocator_active`. This usually indicates pages that the allocator can and probably will soon release back to the OS.
-*   `allocator_rss_bytes`: Delta between `allocator_resident` and `allocator_active`. 
+*   `allocator_rss_bytes`: Delta between `allocator_resident` and `allocator_active`
 *   `rss_overhead_ratio`: Ratio between `used_memory_rss` (the process RSS) and `allocator_resident`. This includes RSS overheads that are not allocator or heap related.
-*   `rss_overhead_bytes`: Delta between `used_memory_rss` (the process RSS) and `allocator_resident`.
+*   `rss_overhead_bytes`: Delta between `used_memory_rss` (the process RSS) and `allocator_resident`
 *   `allocator_allocated`: Total bytes allocated form the allocator, including internal-fragmentation. Normally the same as `used_memory`.
 *   `allocator_active`: Total bytes in the allocator active pages, this includes external-fragmentation.
-*   `allocator_resident`: Total bytes resident (RSS) in the allocator, this includes pages that can be released to the OS (by `MEMORY PURGE`, or just waiting)
-*   `mem_allocator`: Memory allocator, chosen at compile time
-*   `active_defrag_running`: When `activedefrag` is enabled, this indicates whether defragmentation is currently active, and the CPU percentage it intends to utilize
+*   `allocator_resident`: Total bytes resident (RSS) in the allocator, this includes pages that can be released to the OS (by `MEMORY PURGE`, or just waiting).
+*   `mem_allocator`: Memory allocator, chosen at compile time.
+*   `active_defrag_running`: When `activedefrag` is enabled, this indicates whether defragmentation is currently active, and the CPU percentage it intends to utilize.
 *   `lazyfree_pending_objects`: The number of objects waiting to be freed (as a
      result of calling `UNLINK`, or `FLUSHDB` and `FLUSHALL` with the **ASYNC**
      option)


### PR DESCRIPTION
the details about `mem_fragmentation_ratio`, and `activedefrag_running` where misleading.
added lost of info about the breakdown of different RSS related metrics.