### PR TITLE
Add current_cow_peak field in INFO command

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -166,8 +166,10 @@ by referring to the `MEMORY STATS` command and the `MEMORY DOCTOR`.
 Here is the meaning of all fields in the **persistence** section:
 
 *   `loading`: Flag indicating if the load of a dump file is on-going
-*   `current_cow_peak`: The peak size in bytes of copy-on-write memory while a child fork is running
-*   `current_cow_size`: The size in bytes of copy-on-write memory while a child fork is running
+*   `current_cow_peak`: The peak size in bytes of copy-on-write memory
+     while a child fork is running
+*   `current_cow_size`: The size in bytes of copy-on-write memory
+     while a child fork is running
 *   `current_fork_perc`: The percentage of progress of the current fork process. For AOF and RDB forks it is the percentage of `current_save_keys_processed` out of `current_save_keys_total`.
 *   `current_save_keys_processed`: Number of keys processed by the current save operation
 *   `current_save_keys_total`: Number of keys at the beginning of the current save operation 

--- a/commands/info.md
+++ b/commands/info.md
@@ -166,8 +166,8 @@ by referring to the `MEMORY STATS` command and the `MEMORY DOCTOR`.
 Here is the meaning of all fields in the **persistence** section:
 
 *   `loading`: Flag indicating if the load of a dump file is on-going
-*   `current_cow_size`: The size in bytes of copy-on-write memory
-     while a child fork is running
+*   `current_cow_peak`: The peak size in bytes of copy-on-write memory while a child fork is running
+*   `current_cow_size`: The size in bytes of copy-on-write memory while a child fork is running
 *   `current_fork_perc`: The percentage of progress of the current fork process. For AOF and RDB forks it is the percentage of `current_save_keys_processed` out of `current_save_keys_total`.
 *   `current_save_keys_processed`: Number of keys processed by the current save operation
 *   `current_save_keys_total`: Number of keys at the beginning of the current save operation 


### PR DESCRIPTION
In https://github.com/redis/redis/pull/8974, we add `current_cow_peak field` in INFO command