### PR TITLE
Fix spelling of acknowledgment

### DIFF
--- a/commands/client-pause.md
+++ b/commands/client-pause.md
@@ -16,7 +16,7 @@ For the `WRITE` mode, some commands have special behavior:
 * `EVAL`/`EVALSHA`: Will block client for all scripts.
 * `PUBLISH`: Will block client.
 * `PFCOUNT`: Will block client.
-* `WAIT`: Acknowledgements will be delayed, so this command will appear blocked.
+* `WAIT`: Acknowledgments will be delayed, so this command will appear blocked.
 
 This command is useful as it makes able to switch clients from a Redis instance to another one in a controlled way. For example during an instance upgrade the system administrator could do the following:
 


### PR DESCRIPTION
(This is the American vs British spelling)

It looks like this broke because it wasn't correctly parsing the markdown in the past, when the markdown was fixed the rest of the block was parsed correctly.