### PR TITLE
Remove cli tag from GETBIT

### DIFF
--- a/commands/getbit.md
+++ b/commands/getbit.md
@@ -12,9 +12,13 @@ always out of range and the value is also assumed to be a contiguous space with
 
 @examples
 
-```cli
-SETBIT mykey 7 1
-GETBIT mykey 0
-GETBIT mykey 7
-GETBIT mykey 100
+```
+redis> SETBIT mykey 7 1
+(integer) 0
+redis> GETBIT mykey 0
+(integer) 0
+redis> GETBIT mykey 7
+(integer) 1
+redis> GETBIT mykey 100
+(integer) 0
 ```


### PR DESCRIPTION
redis.io page was showing interactive cli for GETBIT which is blocked and threw an error in the response. I removed the cli tag and fixed the example to show how it would look to the user