### PR TITLE
Remove cli tag from SETBIT

### DIFF
--- a/commands/setbit.md
+++ b/commands/setbit.md
@@ -26,10 +26,13 @@ the same _key_ will not have the allocation overhead.
 
 @examples
 
-```cli
-SETBIT mykey 7 1
-SETBIT mykey 7 0
-GET mykey
+```
+redis> SETBIT mykey 7 1
+(integer) 0
+redis> SETBIT mykey 7 0
+(integer) 1
+redis> GET mykey
+"\x00"
 ```
 
 ## Pattern: accessing the entire bitmap


### PR DESCRIPTION
redis.io page was showing interactive cli for SETBIT which is blocked and threw an error in the response. I removed the cli tag and fixed the example to show how it would look to the user