### PR TITLE
Notes on manual failover to a new (just upgraded) replica

### DIFF
--- a/commands/cluster-failover.md
+++ b/commands/cluster-failover.md
@@ -59,7 +59,7 @@ Because of this the **TAKEOVER** option should be used with care.
 * A replica can only be promoted to a master if it is known as a replica by a majority of the masters in the cluster.
   If the replica is a new node that has just been added to the cluster (for example after upgrading it), it may not yet be known to all the masters in the cluster.
   To check that the masters are aware of a new replica, you can send `CLUSTER NODES` or `CLUSTER REPLICAS` to each of the master nodes and check that it appears as a replica, before sending `CLUSTER FAILOVER` to the replica.
-* To check that the failover has actually happened, `INFO REPLICATION` (which indicates "role:master" after successful failover) or `CLUSTER NODES` or other means should be used in order to verify that the state of the cluster has changed some time after the command was sent.
+* To check that the failover has actually happened you can use `ROLE`, `INFO REPLICATION` (which indicates "role:master" after successful failover), or `CLUSTER NODES` to verify that the state of the cluster has changed sometime after the command was sent.
 * To check if the failover has failed, check the replica's log for "Manual failover timed out", which is logged if the replica has given up after a few seconds.
 
 @return

--- a/commands/cluster-failover.md
+++ b/commands/cluster-failover.md
@@ -56,7 +56,7 @@ Because of this the **TAKEOVER** option should be used with care.
 * `CLUSTER FAILOVER`, unless the **TAKEOVER** option is specified, does not execute a failover synchronously.
   It only *schedules* a manual failover, bypassing the failure detection stage.
 * An `OK` reply is no guarantee that the failover will succeed.
-* A replica can only be promoted to a master if is known as a replica by a majority of the masters in the cluster.
+* A replica can only be promoted to a master if it is known as a replica by a majority of the masters in the cluster.
   If the replica is a new node that has just been added to the cluster (for example after upgrading it), it may not yet be known to all the masters in the cluster.
   To check that the masters are aware of a new replica, you can send `CLUSTER NODES` or `CLUSTER REPLICAS` to each of the master nodes and check that it appears as a replica, before sending `CLUSTER FAILOVER` to the replica.
 * To check that the failover has actually happened, `INFO REPLICATION` (which indicates "role:master" after successful failover) or `CLUSTER NODES` or other means should be used in order to verify that the state of the cluster has changed some time after the command was sent.

--- a/commands/cluster-failover.md
+++ b/commands/cluster-failover.md
@@ -53,11 +53,14 @@ Because of this the **TAKEOVER** option should be used with care.
 
 ## Implementation details and notes
 
-`CLUSTER FAILOVER`, unless the **TAKEOVER** option is specified,  does not
-execute a failover synchronously, it only *schedules* a manual failover,
-bypassing the failure detection stage, so to check if the failover actually
-happened, `CLUSTER NODES` or other means should be used in order to verify
-that the state of the cluster changes after some time the command was sent.
+* `CLUSTER FAILOVER`, unless the **TAKEOVER** option is specified, does not execute a failover synchronously.
+  It only *schedules* a manual failover, bypassing the failure detection stage.
+* An `OK` reply is no guarantee that the failover will succeed.
+* A replica can only be promoted to a master if is known as a replica by a majority of the masters in the cluster.
+  If the replica is a new node that has just been added to the cluster (for example after upgrading it), it may not yet be known to all the masters in the cluster.
+  To check that the masters are aware of a new replica, you can send `CLUSTER NODES` or `CLUSTER REPLICAS` to each of the master nodes and check that it appears as a replica, before sending `CLUSTER FAILOVER` to the replica.
+* To check that the failover has actually happened, `INFO REPLICATION` (which indicates "role:master" after successful failover) or `CLUSTER NODES` or other means should be used in order to verify that the state of the cluster has changed some time after the command was sent.
+* To check if the failover has failed, check the replica's log for "Manual failover timed out", which is logged if the replica has given up after a few seconds.
 
 @return
 

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -804,6 +804,12 @@ the failover starts, and the old master is informed about the configuration
 switch. When the clients are unblocked on the old master, they are redirected
 to the new master.
 
+Note:
+
+* To promote a replica to master, it must first be known as a replica by a majority of the masters in the cluster.
+  Otherwise, it cannot win the failover election.
+  If the replica has just been added to the cluster (see [Adding a new node as a replica](#adding-a-new-node-as-a-replica) below), you may need to wait a while before sending the `CLUSTER FAILOVER` command, to make sure the masters in cluster are aware of the new replica.
+
 Adding a new node
 ---
 
@@ -991,7 +997,8 @@ one is not available.
 
 Upgrading masters is a bit more complex, and the suggested procedure is:
 
-1. Use CLUSTER FAILOVER to trigger a manual failover of the master to one of its slaves (see the "Manual failover" section of this documentation).
+1. Use `CLUSTER FAILOVER` to trigger a manual failover of the master to one of its replicas.
+   (See the [Manual failover](#manual-failover) section in this document.)
 2. Wait for the master to turn into a slave.
 3. Finally upgrade the node as you do for slaves.
 4. If you want the master to be the node you just upgraded, trigger a new manual failover in order to turn back the upgraded node into a master.


### PR DESCRIPTION
Some notes are added to CLUSTER FAILOVER command and to the Cluster
Tutorial document, regarding manual failover to a new, just added,
replica.

This scenario was discovered while automating node upgrades using
manual failover.