### PR TITLE
Clarify what pubsub numpat behavior change

### DIFF
--- a/commands/pubsub.md
+++ b/commands/pubsub.md
@@ -39,9 +39,9 @@ will just return an empty list.
 
 # `PUBSUB NUMPAT`
 
-Returns the number of subscriptions to patterns (that are performed using the
-`PSUBSCRIBE` command). Note that this is not just the count of clients subscribed
-to patterns but the total number of patterns all the clients are subscribed to.
+Returns the number of unique patterns that are subscribed to by clients (that are performed using the
+`PSUBSCRIBE` command). Note that this is not the count of clients subscribed
+to patterns but the total number of unique patterns all the clients are subscribed to.
 
 @return
 


### PR DESCRIPTION
Clarifying the return type of pubsub numpat.

Related to this change: https://github.com/redis/redis/pull/9209