### PR TITLE
Correct XGROUP SETID enum type argument definition in comments.json

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -5862,7 +5862,7 @@
       },
       {
         "name": "id",
-        "type": "string",
+        "type": "enum",
         "enum": [
           "id",
           "$"


### PR DESCRIPTION
Hi, I found a little inconsistent in the comments.json. I think `id` argument in the `XGROUP SETID` should be labeled as `type=enum` to align with others.