### PR TITLE
fix inconsistency between example about how to run and description

### DIFF
--- a/topics/modules-intro.md
+++ b/topics/modules-intro.md
@@ -187,7 +187,7 @@ file name:
 
     loadmodule mymodule.so foo bar 1234
 
-In the above example the strings `foo`, `bar` and `123` will be passed
+In the above example the strings `foo`, `bar` and `1234` will be passed
 to the module `OnLoad()` function in the `argv` argument as an array
 of RedisModuleString pointers. The number of arguments passed is into `argc`.
 


### PR DESCRIPTION
The example uses 1234 as argument. But, on the other hand, description explains using 123.

```
loadmodule mymodule.so foo bar 1234
```

So I fixed inconsistency between example about how to run and description