### PR TITLE
Add API documentation for CLUSTER LINKS command

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1042,6 +1042,12 @@
     "since": "3.0.0",
     "group": "cluster"
   },
+  "CLUSTER LINKS": {
+    "summary": "Returns a list of all TCP links to and from peer nodes in cluster",
+    "complexity": "O(N) where N is the total number of Cluster nodes",
+    "since": "7.0.0",
+    "group": "cluster"
+  },
   "CLUSTER MEET": {
     "summary": "Force a node cluster to handshake with another node",
     "complexity": "O(1)",

--- a/commands/cluster-info.md
+++ b/commands/cluster-info.md
@@ -14,6 +14,7 @@ cluster_current_epoch:6
 cluster_my_epoch:2
 cluster_stats_messages_sent:1483972
 cluster_stats_messages_received:1483968
+total_cluster_links_buffer_limit_exceeded:0
 ```
 
 * `cluster_state`: State is `ok` if the node is able to receive queries. `fail` if there is at least one hash slot which is unbound (no node associated), in error state (node serving it is flagged with FAIL flag), or if the majority of masters can't be reached by this node.
@@ -27,6 +28,7 @@ cluster_stats_messages_received:1483968
 * `cluster_my_epoch`: The `Config Epoch` of the node we are talking with. This is the current configuration version assigned to this node.
 * `cluster_stats_messages_sent`: Number of messages sent via the cluster node-to-node binary bus.
 * `cluster_stats_messages_received`: Number of messages received via the cluster node-to-node binary bus.
+* `total_cluster_links_buffer_limit_exceeded`: Accumulated count of cluster links freed due to exceeding the `cluster-link-sendbuf-limit` configuration.
 
 More information about the Current Epoch and Config Epoch variables are available in the Redis Cluster specification document.
 

--- a/commands/cluster-links.md
+++ b/commands/cluster-links.md
@@ -1,0 +1,48 @@
+Each node in a Redis Cluster maintains a pair of long-lived TCP link with each peer in the cluster: One for sending outbound messages towards the peer and one for receiving inbound messages from the peer.
+
+`CLUSTER LINKS` outputs information of all such peer links as an array, where each array element is a map that contains attributes and their values for an individual link.
+
+@examples
+
+The following is an example output:
+
+```
+> CLUSTER LINKS
+1)  1) "direction"
+    2) "to"
+    3) "node"
+    4) "8149d745fa551e40764fecaf7cab9dbdf6b659ae"
+    5) "create-time"
+    6) (integer) 1639442739375
+    7) "events"
+    8) "rw"
+    9) "send-buffer-allocated"
+   10) (integer) 4512
+   11) "send-buffer-used"
+   12) (integer) 0
+2)  1) "direction"
+    2) "from"
+    3) "node"
+    4) "8149d745fa551e40764fecaf7cab9dbdf6b659ae"
+    5) "create-time"
+    6) (integer) 1639442739411
+    7) "events"
+    8) "r"
+    9) "send-buffer-allocated"
+   10) (integer) 0
+   11) "send-buffer-used"
+   12) (integer) 0
+```
+
+Each map is composed of the following attributes of the corresponding cluster link and their values:
+
+1. `direction`: This link is established by the local node `to` the peer, or accepted by the local node `from` the peer.
+2. `node`: The node id of the peer.
+3. `create-time`: Creation time of the link. (In the case of a `to` link, this is the time when the TCP link is created by the local node, not the time when it is actually established.)
+4. `events`: Events currently registered for the link. `r` means readable event, `w` means writable event.
+5. `send-buffer-allocated`: Allocated size of the link's send buffer, which is used to buffer outgoing messages toward the peer.
+6. `send-buffer-used`: Size of the portion of the link's send buffer that is currently holding data(messages).
+
+@return
+
+@array-reply: An array of maps where each map contains various attributes and their values of a cluster link.

--- a/commands/info.md
+++ b/commands/info.md
@@ -137,8 +137,9 @@ Here is the meaning of all fields in the **memory** section:
 *   `allocator_active`: Total bytes in the allocator active pages, this includes external-fragmentation.
 *   `allocator_resident`: Total bytes resident (RSS) in the allocator, this includes pages that can be released to the OS (by `MEMORY PURGE`, or just waiting).
 *   `mem_not_counted_for_evict`: Used memory that's not counted for key eviction. This is basically transient replica and AOF buffers.
-*   `mem_clients_normal`: Memory used by normal clients
 *   `mem_clients_slaves`: Memory used by replica clients - Starting Redis 7.0, replica buffers share memory with the replication backlog, so this field can show 0 when replicas don't trigger an increase of memory usage.
+*   `mem_clients_normal`: Memory used by normal clients
+*   `mem_cluster_links`: Memory used by links to peers on the cluster bus when cluster mode is enabled.
 *   `mem_aof_buffer`: Transient memory used for AOF and AOF rewrite buffers
 *   `mem_replication_backlog`: Memory used by replication backlog
 *   `mem_total_replication_buffers`: Total memory consumed for replication buffers - Added in Redis 7.0.


### PR DESCRIPTION
* Add API documentation for `CLUSTER LINKS` command;
* Add `mem_cluster_links` field to API document of INFO command;
* Add `total_cluster_links_buffer_limit_exceeded` field to API document of CLUSTER INFO command

Related Redis changes: https://github.com/redis/redis/pull/9774