### PR TITLE
Removes @history and deprecation notices

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -3459,6 +3459,12 @@
         "since": "1.0.0",
         "group": "generic",
         "complexity": "O(N) where N is the number of keys to check.",
+        "history": [
+            [
+                "3.0.3",
+                "Accepts multiple `key` arguments."
+            ]
+        ],
         "acl_categories": [
             "@keyspace",
             "@read",
@@ -3917,6 +3923,16 @@
         "since": "1.0.0",
         "group": "server",
         "complexity": "O(N) where N is the number of keys in the selected database",
+        "history": [
+            [
+                "4.0.0",
+                "Added the `ASYNC` flushing mode modifier."
+            ],
+            [
+                "6.2.0",
+                "Added the `SYNC` flushing mode modifier and the **lazyfree-lazy-user-flush** configuration directive."
+            ]
+        ],
         "acl_categories": [
             "@keyspace",
             "@write",
@@ -5819,6 +5835,12 @@
         "since": "2.0.0",
         "group": "hash",
         "complexity": "O(N) where N is the number of fields to be removed.",
+        "history": [
+            [
+                "2.4.0",
+                "Accepts multiple `field` arguments."
+            ]
+        ],
         "acl_categories": [
             "@write",
             "@hash",
@@ -6472,6 +6494,12 @@
         "since": "2.0.0",
         "group": "hash",
         "complexity": "O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.",
+        "history": [
+            [
+                "4.0.0",
+                "Accepts multiple `field` and `value` arguments."
+            ]
+        ],
         "acl_categories": [
             "@write",
             "@hash",
@@ -9216,6 +9244,12 @@
         "since": "2.6.0",
         "group": "generic",
         "complexity": "O(1)",
+        "history": [
+            [
+                "2.8.0",
+                "Added the -2 reply."
+            ]
+        ],
         "acl_categories": [
             "@keyspace",
             "@read",
@@ -9461,6 +9495,12 @@
         "since": "1.0.0",
         "group": "generic",
         "complexity": "O(1)",
+        "history": [
+            [
+                "3.2.0",
+                "The command no longer returns an error when source and destination names are the same."
+            ]
+        ],
         "acl_categories": [
             "@keyspace",
             "@write",
@@ -9507,6 +9547,12 @@
         "since": "1.0.0",
         "group": "generic",
         "complexity": "O(1)",
+        "history": [
+            [
+                "3.2.0",
+                "The command no longer returns an error when source and destination names are the same."
+            ]
+        ],
         "acl_categories": [
             "@keyspace",
             "@write",
@@ -9620,6 +9666,20 @@
         "since": "2.6.0",
         "group": "generic",
         "complexity": "O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).",
+        "history": [
+            [
+                "3.0.0",
+                "Added the `REPLACE` modifier."
+            ],
+            [
+                "5.0.0",
+                "Added the `ABSTTL` modifier."
+            ],
+            [
+                "5.0.0",
+                "Added the `IDLETIME` and `FREQ` options."
+            ]
+        ],
         "acl_categories": [
             "@keyspace",
             "@write",
@@ -10054,6 +10114,12 @@
         "since": "2.8.0",
         "group": "generic",
         "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.",
+        "history": [
+            [
+                "6.0",
+                "Added the `TYPE` subcommand."
+            ]
+        ],
         "acl_categories": [
             "@keyspace",
             "@read",
@@ -12025,6 +12091,12 @@
         "since": "1.0.0",
         "group": "generic",
         "complexity": "O(1)",
+        "history": [
+            [
+                "2.8.0",
+                "Added the -2 reply."
+            ]
+        ],
         "acl_categories": [
             "@keyspace",
             "@read",
@@ -13252,6 +13324,12 @@
         "since": "5.0.0",
         "group": "stream",
         "complexity": "O(N) with N being the number of elements being returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
+        "history": [
+            [
+                "6.2",
+                "Added exclusive ranges."
+            ]
+        ],
         "acl_categories": [
             "@read",
             "@stream",
@@ -13466,6 +13544,12 @@
         "since": "5.0.0",
         "group": "stream",
         "complexity": "O(N) with N being the number of elements returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
+        "history": [
+            [
+                "6.2",
+                "Added exclusive ranges."
+            ]
+        ],
         "acl_categories": [
             "@read",
             "@stream",
@@ -14776,6 +14860,12 @@
         "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
         "deprecated_since": "6.2.0",
         "replaced_by": "`ZRANGE` with the `BYSCORE` argument",
+        "history": [
+            [
+                "2.0.0",
+                "Added the `WITHSCORES` modifier."
+            ]
+        ],
         "acl_categories": [
             "@read",
             "@sortedset",
@@ -15339,6 +15429,12 @@
         "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
         "deprecated_since": "6.2.0",
         "replaced_by": "`ZRANGE` with the `REV` and `BYSCORE` arguments",
+        "history": [
+            [
+                "2.1.6",
+                "`min` and `max` can be exclusive."
+            ]
+        ],
         "acl_categories": [
             "@read",
             "@sortedset",

--- a/commands.json
+++ b/commands.json
@@ -4879,7 +4879,7 @@
     },
     "GEORADIUSBYMEMBER_RO": {
         "summary": "A read-only variant for GEORADIUSBYMEMBER",
-        "since": "5.0.0",
+        "since": "3.2.10",
         "group": "geo",
         "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
         "deprecated_since": "6.2.0",
@@ -5012,7 +5012,7 @@
     },
     "GEORADIUS_RO": {
         "summary": "A read-only variant for GEORADIUS",
-        "since": "5.0.0",
+        "since": "3.2.10",
         "group": "geo",
         "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
         "deprecated_since": "6.2.0",

--- a/commands.json
+++ b/commands.json
@@ -85,7 +85,7 @@
         "complexity": "O(N). Where N is the number of password, command and pattern rules that the user has.",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added Pub/Sub channel patterns."
             ]
         ],
@@ -219,7 +219,7 @@
         "complexity": "O(N). Where N is the number of rules provided.",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added Pub/Sub channel patterns."
             ]
         ],
@@ -362,6 +362,7 @@
             {
                 "name": "username",
                 "type": "string",
+                "since": "6.0.0",
                 "optional": true
             },
             {
@@ -415,6 +416,7 @@
                 "name": "schedule",
                 "type": "pure-token",
                 "token": "SCHEDULE",
+                "since": "3.2.2",
                 "optional": true
             }
         ],
@@ -430,7 +432,7 @@
         "complexity": "O(N)",
         "history": [
             [
-                "7.0",
+                "7.0.0",
                 "Added the `BYTE|BIT` option."
             ]
         ],
@@ -481,6 +483,7 @@
                     {
                         "name": "index_unit",
                         "type": "oneof",
+                        "since": "7.0.0",
                         "optional": true,
                         "arguments": [
                             {
@@ -756,7 +759,7 @@
         "complexity": "O(N)",
         "history": [
             [
-                "7.0",
+                "7.0.0",
                 "Added the `BYTE|BIT` option."
             ]
         ],
@@ -816,6 +819,7 @@
                             {
                                 "name": "index_unit",
                                 "type": "oneof",
+                                "since": "7.0.0",
                                 "optional": true,
                                 "arguments": [
                                     {
@@ -1023,7 +1027,7 @@
         "complexity": "O(N) where N is the number of provided keys.",
         "history": [
             [
-                "6.0",
+                "6.0.0",
                 "`timeout` is interpreted as a double instead of an integer."
             ]
         ],
@@ -1077,7 +1081,7 @@
         "complexity": "O(N) where N is the number of provided keys.",
         "history": [
             [
-                "6.0",
+                "6.0.0",
                 "`timeout` is interpreted as a double instead of an integer."
             ]
         ],
@@ -1133,7 +1137,7 @@
         "replaced_by": "`BLMOVE` with the `RIGHT` and `LEFT` arguments",
         "history": [
             [
-                "6.0",
+                "6.0.0",
                 "`timeout` is interpreted as a double instead of an integer."
             ]
         ],
@@ -1287,7 +1291,7 @@
         "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
         "history": [
             [
-                "6.0",
+                "6.0.0",
                 "`timeout` is interpreted as a double instead of an integer."
             ]
         ],
@@ -1342,7 +1346,7 @@
         "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
         "history": [
             [
-                "6.0",
+                "6.0.0",
                 "`timeout` is interpreted as a double instead of an integer."
             ]
         ],
@@ -1522,22 +1526,22 @@
         "history": [
             [
                 "2.8.12",
-                "Added new filter format. "
+                "Added new filter format."
             ],
             [
                 "2.8.12",
                 "`ID` option."
             ],
             [
-                "3.2",
+                "3.2.0",
                 "Added `master` type in for `TYPE` option."
             ],
             [
-                "5",
+                "5.0.0",
                 "Replaced `slave` `TYPE` with `replica`. `slave` still supported for backward compatibility."
             ],
             [
-                "6.2",
+                "6.2.0",
                 "`LADDR` option."
             ]
         ],
@@ -1558,12 +1562,14 @@
                 "name": "client-id",
                 "type": "integer",
                 "token": "ID",
+                "since": "2.8.12",
                 "optional": true
             },
             {
                 "name": "normal_master_slave_pubsub",
                 "type": "oneof",
                 "token": "TYPE",
+                "since": "2.8.12",
                 "optional": true,
                 "arguments": [
                     {
@@ -1574,12 +1580,19 @@
                     {
                         "name": "master",
                         "type": "pure-token",
-                        "token": "MASTER"
+                        "token": "MASTER",
+                        "since": "3.2.0"
                     },
                     {
                         "name": "slave",
                         "type": "pure-token",
                         "token": "SLAVE"
+                    },
+                    {
+                        "name": "replica",
+                        "type": "pure-token",
+                        "token": "REPLICA",
+                        "since": "5.0.0"
                     },
                     {
                         "name": "pubsub",
@@ -1604,6 +1617,7 @@
                 "name": "ip:port",
                 "type": "string",
                 "token": "LADDR",
+                "since": "6.2.0",
                 "optional": true
             },
             {
@@ -1631,11 +1645,11 @@
                 "Added unique client `id` field."
             ],
             [
-                "5.0",
+                "5.0.0",
                 "Added optional `TYPE` filter."
             ],
             [
-                "6.2",
+                "6.2.0",
                 "Added `laddr` field and the optional `ID` filter."
             ]
         ],
@@ -1651,6 +1665,7 @@
                 "name": "normal_master_replica_pubsub",
                 "type": "oneof",
                 "token": "TYPE",
+                "since": "5.0.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -1679,6 +1694,7 @@
                 "name": "id",
                 "type": "block",
                 "token": "ID",
+                "since": "6.2.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -1745,8 +1761,8 @@
                 "Client pause prevents client pause and key eviction as well."
             ],
             [
-                "6.2",
-                "CLIENT PAUSE WRITE mode added along with the `mode` option."
+                "6.2.0",
+                "`CLIENT PAUSE WRITE` mode added along with the `mode` option."
             ]
         ],
         "acl_categories": [
@@ -1764,6 +1780,7 @@
             {
                 "name": "mode",
                 "type": "oneof",
+                "since": "6.2.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -2603,7 +2620,7 @@
         "complexity": "O(N) where N is the total number of Cluster nodes",
         "history": [
             [
-                "4.0",
+                "4.0.0",
                 "Added node IDs."
             ]
         ],
@@ -3510,7 +3527,7 @@
         "complexity": "O(1)",
         "history": [
             [
-                "7.0",
+                "7.0.0",
                 "Added options: `NX`, `XX`, `GT` and `LT`."
             ]
         ],
@@ -3552,6 +3569,7 @@
             {
                 "name": "condition",
                 "type": "oneof",
+                "since": "7.0.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -3589,7 +3607,7 @@
         "complexity": "O(1)",
         "history": [
             [
-                "7.0",
+                "7.0.0",
                 "Added options: `NX`, `XX`, `GT` and `LT`."
             ]
         ],
@@ -3631,6 +3649,7 @@
             {
                 "name": "condition",
                 "type": "oneof",
+                "since": "7.0.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -3904,12 +3923,14 @@
                     {
                         "name": "async",
                         "type": "pure-token",
-                        "token": "ASYNC"
+                        "token": "ASYNC",
+                        "since": "4.0.0"
                     },
                     {
                         "name": "sync",
                         "type": "pure-token",
-                        "token": "SYNC"
+                        "token": "SYNC",
+                        "since": "6.2.0"
                     }
                 ]
             }
@@ -3949,12 +3970,14 @@
                     {
                         "name": "async",
                         "type": "pure-token",
-                        "token": "ASYNC"
+                        "token": "ASYNC",
+                        "since": "4.0.0"
                     },
                     {
                         "name": "sync",
                         "type": "pure-token",
-                        "token": "SYNC"
+                        "token": "SYNC",
+                        "since": "6.2.0"
                     }
                 ]
             }
@@ -4220,7 +4243,7 @@
         "complexity": "O(log(N)) for each item added, where N is the number of elements in the sorted set.",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added the `CH`, `NX` and `XX` options."
             ]
         ],
@@ -4258,6 +4281,7 @@
             {
                 "name": "condition",
                 "type": "oneof",
+                "since": "6.2.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -4276,6 +4300,7 @@
                 "name": "change",
                 "type": "pure-token",
                 "token": "CH",
+                "since": "6.2.0",
                 "optional": true
             },
             {
@@ -4480,7 +4505,7 @@
         "replaced_by": "`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` argument",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added the `ANY` option for `COUNT`."
             ]
         ],
@@ -4621,6 +4646,7 @@
                         "name": "any",
                         "type": "pure-token",
                         "token": "ANY",
+                        "since": "6.2.0",
                         "optional": true
                     }
                 ]
@@ -5123,7 +5149,7 @@
     },
     "GEOSEARCH": {
         "summary": "Query a sorted set representing a geospatial index to fetch members inside an area of a box or a circle.",
-        "since": "6.2",
+        "since": "6.2.0",
         "group": "geo",
         "complexity": "O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape",
         "acl_categories": [
@@ -5319,7 +5345,7 @@
     },
     "GEOSEARCHSTORE": {
         "summary": "Query a sorted set representing a geospatial index to fetch members inside an area of a box or a circle, and store the result in another key.",
-        "since": "6.2",
+        "since": "6.2.0",
         "group": "geo",
         "complexity": "O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape",
         "acl_categories": [
@@ -5890,7 +5916,7 @@
         "complexity": "O(1)",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "`protover` made optional; when called without arguments the command reports the current connection's context."
             ]
         ],
@@ -7445,7 +7471,7 @@
         "complexity": "O(N) where N is the number of elements returned",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added the `count` argument."
             ]
         ],
@@ -7483,6 +7509,7 @@
             {
                 "name": "count",
                 "type": "integer",
+                "since": "6.2.0",
                 "optional": true
             }
         ],
@@ -7561,7 +7588,7 @@
         "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
         "history": [
             [
-                "2.4",
+                "2.4.0",
                 "Accepts multiple `element` arguments."
             ]
         ],
@@ -7615,7 +7642,7 @@
         "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
         "history": [
             [
-                "4.0",
+                "4.0.0",
                 "Accepts multiple `element` arguments."
             ]
         ],
@@ -8126,24 +8153,28 @@
                 "name": "copy",
                 "type": "pure-token",
                 "token": "COPY",
+                "since": "3.0.0",
                 "optional": true
             },
             {
                 "name": "replace",
                 "type": "pure-token",
                 "token": "REPLACE",
+                "since": "3.0.0",
                 "optional": true
             },
             {
                 "name": "password",
                 "type": "string",
                 "token": "AUTH",
+                "since": "4.0.7",
                 "optional": true
             },
             {
                 "name": "username_password",
                 "type": "block",
                 "token": "AUTH2",
+                "since": "6.0.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -8161,6 +8192,7 @@
                 "type": "key",
                 "key_spec_index": 1,
                 "token": "KEYS",
+                "since": "3.0.6",
                 "optional": true,
                 "multiple": true
             }
@@ -8267,11 +8299,11 @@
         "group": "server",
         "history": [
             [
-                "6.0",
+                "6.0.0",
                 "`AUTH` excluded from the command's output."
             ],
             [
-                "6.2",
+                "6.2.0",
                 "`RESET` can be called to exit monitor mode."
             ],
             [
@@ -8701,7 +8733,7 @@
         "complexity": "O(1)",
         "history": [
             [
-                "7.0",
+                "7.0.0",
                 "Added options: `NX`, `XX`, `GT` and `LT`."
             ]
         ],
@@ -8743,6 +8775,7 @@
             {
                 "name": "condition",
                 "type": "oneof",
+                "since": "7.0.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -8780,7 +8813,7 @@
         "complexity": "O(1)",
         "history": [
             [
-                "7.0",
+                "7.0.0",
                 "Added options: `NX`, `XX`, `GT` and `LT`."
             ]
         ],
@@ -8822,6 +8855,7 @@
             {
                 "name": "condition",
                 "type": "oneof",
+                "since": "7.0.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -9724,24 +9758,28 @@
                 "name": "replace",
                 "type": "pure-token",
                 "token": "REPLACE",
+                "since": "3.0.0",
                 "optional": true
             },
             {
                 "name": "absttl",
                 "type": "pure-token",
                 "token": "ABSTTL",
+                "since": "5.0.0",
                 "optional": true
             },
             {
                 "name": "seconds",
                 "type": "integer",
                 "token": "IDLETIME",
+                "since": "5.0.0",
                 "optional": true
             },
             {
                 "name": "frequency",
                 "type": "integer",
                 "token": "FREQ",
+                "since": "5.0.0",
                 "optional": true
             }
         ],
@@ -9815,7 +9853,7 @@
         "complexity": "O(N) where N is the number of elements returned",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added the `count` argument."
             ]
         ],
@@ -9853,6 +9891,7 @@
             {
                 "name": "count",
                 "type": "integer",
+                "since": "6.2.0",
                 "optional": true
             }
         ],
@@ -9938,7 +9977,7 @@
         "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
         "history": [
             [
-                "2.4",
+                "2.4.0",
                 "Accepts multiple `element` arguments."
             ]
         ],
@@ -9992,7 +10031,7 @@
         "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
         "history": [
             [
-                "4.0",
+                "4.0.0",
                 "Accepts multiple `element` arguments."
             ]
         ],
@@ -10046,7 +10085,7 @@
         "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
         "history": [
             [
-                "2.4",
+                "2.4.0",
                 "Accepts multiple `member` arguments."
             ]
         ],
@@ -10116,7 +10155,7 @@
         "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.",
         "history": [
             [
-                "6.0",
+                "6.0.0",
                 "Added the `TYPE` subcommand."
             ]
         ],
@@ -10147,6 +10186,7 @@
                 "name": "type",
                 "type": "string",
                 "token": "TYPE",
+                "since": "6.0.0",
                 "optional": true
             }
         ],
@@ -10285,6 +10325,7 @@
             {
                 "name": "async",
                 "type": "oneof",
+                "since": "6.2.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -10494,15 +10535,15 @@
                 "Added the `EX`, `PX`, `NX` and `XX` options."
             ],
             [
-                "6.0",
+                "6.0.0",
                 "Added the `KEEPTTL` option."
             ],
             [
-                "6.2",
+                "6.2.0",
                 "Added the `GET`, `EXAT` and `PXAT` option."
             ],
             [
-                "7.0",
+                "7.0.0",
                 "Allowed the `NX` and `GET` options to be used together."
             ]
         ],
@@ -10550,33 +10591,39 @@
                     {
                         "name": "seconds",
                         "type": "integer",
-                        "token": "EX"
+                        "token": "EX",
+                        "since": "2.6.12"
                     },
                     {
                         "name": "milliseconds",
                         "type": "integer",
-                        "token": "PX"
+                        "token": "PX",
+                        "since": "2.6.12"
                     },
                     {
                         "name": "unix-time-seconds",
                         "type": "unix-time",
-                        "token": "EXAT"
+                        "token": "EXAT",
+                        "since": "6.2.0"
                     },
                     {
                         "name": "unix-time-milliseconds",
                         "type": "unix-time",
-                        "token": "PXAT"
+                        "token": "PXAT",
+                        "since": "6.2.0"
                     },
                     {
                         "name": "keepttl",
                         "type": "pure-token",
-                        "token": "KEEPTTL"
+                        "token": "KEEPTTL",
+                        "since": "6.0.0"
                     }
                 ]
             },
             {
                 "name": "condition",
                 "type": "oneof",
+                "since": "2.6.12",
                 "optional": true,
                 "arguments": [
                     {
@@ -11087,7 +11134,7 @@
         "complexity": "O(N) where N is the number of entries returned",
         "history": [
             [
-                "4.0",
+                "4.0.0",
                 "Added client IP address, port and name to the reply."
             ]
         ],
@@ -11540,7 +11587,7 @@
         "complexity": "Without the count argument O(1), otherwise O(N) where N is the value of the passed count.",
         "history": [
             [
-                "3.2",
+                "3.2.0",
                 "Added the `count` argument."
             ]
         ],
@@ -11578,6 +11625,7 @@
             {
                 "name": "count",
                 "type": "integer",
+                "since": "3.2.0",
                 "optional": true
             }
         ],
@@ -11632,6 +11680,7 @@
             {
                 "name": "count",
                 "type": "integer",
+                "since": "2.6.0",
                 "optional": true
             }
         ],
@@ -11647,7 +11696,7 @@
         "complexity": "O(N) where N is the number of members to be removed.",
         "history": [
             [
-                "2.4",
+                "2.4.0",
                 "Accepts multiple `member` arguments."
             ]
         ],
@@ -11800,7 +11849,7 @@
         "complexity": "O(N) where N is the number of channels to subscribe to.",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "`RESET` can be called to exit subscribed state."
             ]
         ],
@@ -12388,11 +12437,11 @@
         "complexity": "O(1) when adding a new entry, O(N) when trimming where N being the number of entries evicted.",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added the `NOMKSTREAM` option, `MINID` trimming strategy and the `LIMIT` option."
             ],
             [
-                "7.0",
+                "7.0.0",
                 "Added support for the `<ms>-*` explicit ID form."
             ]
         ],
@@ -12431,7 +12480,7 @@
                 "name": "nomkstream",
                 "type": "pure-token",
                 "token": "NOMKSTREAM",
-                "since": "6.2",
+                "since": "6.2.0",
                 "optional": true
             },
             {
@@ -12452,7 +12501,7 @@
                                 "name": "minid",
                                 "type": "pure-token",
                                 "token": "MINID",
-                                "since": "6.2"
+                                "since": "6.2.0"
                             }
                         ]
                     },
@@ -12481,7 +12530,7 @@
                         "name": "count",
                         "type": "integer",
                         "token": "LIMIT",
-                        "since": "6.2",
+                        "since": "6.2.0",
                         "optional": true
                     }
                 ]
@@ -13292,6 +13341,7 @@
                         "name": "min-idle-time",
                         "type": "integer",
                         "token": "IDLE",
+                        "since": "6.2.0",
                         "optional": true
                     },
                     {
@@ -13326,7 +13376,7 @@
         "complexity": "O(N) with N being the number of elements being returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added exclusive ranges."
             ]
         ],
@@ -13546,7 +13596,7 @@
         "complexity": "O(N) with N being the number of elements returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added exclusive ranges."
             ]
         ],
@@ -13654,7 +13704,7 @@
         "complexity": "O(N), with N being the number of evicted entries. Constant times are very small however, since entries are organized in macro nodes containing multiple entries that can be released with a single deallocation.",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added the `MINID` trimming strategy and the `LIMIT` option."
             ]
         ],
@@ -13705,7 +13755,8 @@
                             {
                                 "name": "minid",
                                 "type": "pure-token",
-                                "token": "MINID"
+                                "token": "MINID",
+                                "since": "6.2.0"
                             }
                         ]
                     },
@@ -13734,6 +13785,7 @@
                         "name": "count",
                         "type": "integer",
                         "token": "LIMIT",
+                        "since": "6.2.0",
                         "optional": true
                     }
                 ]
@@ -13751,7 +13803,7 @@
         "complexity": "O(log(N)) for each item added, where N is the number of elements in the sorted set.",
         "history": [
             [
-                "2.4",
+                "2.4.0",
                 "Accepts multiple elements."
             ],
             [
@@ -13759,7 +13811,7 @@
                 "Added the `XX`, `NX`, `CH` and `INCR` options."
             ],
             [
-                "6.2",
+                "6.2.0",
                 "Added the `GT` and `LT` options."
             ]
         ],
@@ -13797,6 +13849,7 @@
             {
                 "name": "condition",
                 "type": "oneof",
+                "since": "6.2.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -13814,6 +13867,7 @@
             {
                 "name": "comparison",
                 "type": "oneof",
+                "since": "3.0.2",
                 "optional": true,
                 "arguments": [
                     {
@@ -13832,12 +13886,14 @@
                 "name": "change",
                 "type": "pure-token",
                 "token": "CH",
+                "since": "3.0.2",
                 "optional": true
             },
             {
                 "name": "increment",
                 "type": "pure-token",
                 "token": "INCR",
+                "since": "3.0.2",
                 "optional": true
             },
             {
@@ -14690,7 +14746,7 @@
         "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.",
         "history": [
             [
-                "6.2",
+                "6.2.0",
                 "Added the `REV`, `BYSCORE`, `BYLEX` and `LIMIT` options."
             ]
         ],
@@ -14736,6 +14792,7 @@
             {
                 "name": "sortby",
                 "type": "oneof",
+                "since": "6.2.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -14754,12 +14811,14 @@
                 "name": "rev",
                 "type": "pure-token",
                 "token": "REV",
+                "since": "6.2.0",
                 "optional": true
             },
             {
                 "name": "offset_count",
                 "type": "block",
                 "token": "LIMIT",
+                "since": "6.2.0",
                 "optional": true,
                 "arguments": [
                     {
@@ -14909,6 +14968,7 @@
                 "name": "withscores",
                 "type": "pure-token",
                 "token": "WITHSCORES",
+                "since": "2.0.0",
                 "optional": true
             },
             {
@@ -15099,7 +15159,7 @@
         "complexity": "O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.",
         "history": [
             [
-                "2.4",
+                "2.4.0",
                 "Accepts multiple elements."
             ]
         ],

--- a/commands/acl-getuser.md
+++ b/commands/acl-getuser.md
@@ -8,10 +8,6 @@ the set of rules used to configure the user, it is still functionally identical.
 
 @array-reply: a list of ACL rule definitions for the user.
 
-@history
-
-* `>= 6.2`: Added Pub/Sub channel patterns.
-
 @examples
 
 Here's the default configuration for the default user:

--- a/commands/acl-setuser.md
+++ b/commands/acl-setuser.md
@@ -70,10 +70,6 @@ This is a list of all the supported Redis ACL rules:
 
 If the rules contain errors, the error is returned.
 
-@history
-
-* `>= 6.2`: Added Pub/Sub channel patterns.
-
 @examples
 
 ```

--- a/commands/auth.md
+++ b/commands/auth.md
@@ -24,10 +24,6 @@ defined in the ACL list (see `ACL SETUSER`) and the official [ACL guide](/topics
 
 When ACLs are used, the single argument form of the command, where only the password is specified, assumes that the implicit username is "default".
 
-@history
-
-* `>= 6.0.0`: Added ACL style (username and password).
-
 ## Security notice
 
 Because of the high performance nature of Redis, it is possible to try

--- a/commands/bgsave.md
+++ b/commands/bgsave.md
@@ -22,7 +22,3 @@ Please refer to the [persistence documentation][tp] for detailed information.
 @return
 
 @simple-string-reply: `Background saving started` if `BGSAVE` started correctly or `Background saving scheduled` when used with the `SCHEDULE` subcommand. 
-
-@history
-
-* `>= 3.2.2`: Added the `SCHEDULE` option.

--- a/commands/bitcount.md
+++ b/commands/bitcount.md
@@ -21,10 +21,6 @@ For negative values, -1 is the last bit, -2 is the penultimate, and so forth.
 
 The number of bits set to 1.
 
-@history
-
-* `>= 7.0`: Added the `BYTE|BIT` option.
-
 @examples
 
 ```cli

--- a/commands/bitpos.md
+++ b/commands/bitpos.md
@@ -36,10 +36,6 @@ Basically, the function considers the right of the string as padded with zeros i
 
 However, this behavior changes if you are looking for clear bits and specify a range with both __start__ and __end__. If no clear bit is found in the specified range, the function returns -1 as the user specified a clear range and there are no 0 bits in that range.
 
-@history
-
-* `>= 7.0`: Added the `BYTE|BIT` option.
-
 @examples
 
 ```cli

--- a/commands/blpop.md
+++ b/commands/blpop.md
@@ -91,10 +91,6 @@ If you like science fiction, think of time flowing at infinite speed inside a
   where an element was popped and the second element being the value of the
   popped element.
 
-@history
-
-* `>= 6.0`: `timeout` is interpreted as a double instead of an integer.
-
 @examples
 
 ```

--- a/commands/brpop.md
+++ b/commands/brpop.md
@@ -19,10 +19,6 @@ the tail of a list instead of popping from the head.
   where an element was popped and the second element being the value of the
   popped element.
 
-@history
-
-* `>= 6.0`: `timeout` is interpreted as a double instead of an integer.
-
 @examples
 
 ```

--- a/commands/brpoplpush.md
+++ b/commands/brpoplpush.md
@@ -15,10 +15,6 @@ See `RPOPLPUSH` for more information.
 @bulk-string-reply: the element being popped from `source` and pushed to `destination`.
 If `timeout` is reached, a @nil-reply is returned.
 
-@history
-
-* `>= 6.0`: `timeout` is interpreted as a double instead of an integer.
-
 ## Pattern: Reliable queue
 
 Please see the pattern description in the `RPOPLPUSH` documentation.

--- a/commands/brpoplpush.md
+++ b/commands/brpoplpush.md
@@ -5,9 +5,6 @@ When `source` is empty, Redis will block the connection until another client
 pushes to it or until `timeout` is reached.
 A `timeout` of zero can be used to block indefinitely.
 
-As per Redis 6.2.0, BRPOPLPUSH is considered deprecated. Please prefer `BLMOVE` in
-new code.
-
 See `RPOPLPUSH` for more information.
 
 @return

--- a/commands/bzpopmax.md
+++ b/commands/bzpopmax.md
@@ -23,10 +23,6 @@ with the highest scores instead of popping the ones with the lowest scores.
   where a member was popped, the second element is the popped member itself,
   and the third element is the score of the popped element.
 
-@history
-
-* `>= 6.0`: `timeout` is interpreted as a double instead of an integer.
-
 @examples
 
 ```

--- a/commands/bzpopmin.md
+++ b/commands/bzpopmin.md
@@ -23,10 +23,6 @@ popped from.
   where a member was popped, the second element is the popped member itself,
   and the third element is the score of the popped element.
 
-@history
-
-* `>= 6.0`: `timeout` is interpreted as a double instead of an integer.
-
 @examples
 
 ```

--- a/commands/client-kill.md
+++ b/commands/client-kill.md
@@ -51,11 +51,3 @@ When called with the three arguments format:
 When called with the filter / value format:
 
 @integer-reply: the number of clients killed.
-
-@history
-
-* `>= 2.8.12`: Added new filter format. 
-* `>= 2.8.12`: `ID` option.
-* `>= 3.2`: Added `master` type in for `TYPE` option.
-* `>= 5`: Replaced `slave` `TYPE` with `replica`. `slave` still supported for backward compatibility.
-* `>= 6.2`: `LADDR` option.

--- a/commands/client-list.md
+++ b/commands/client-list.md
@@ -74,9 +74,3 @@ New fields are regularly added for debugging purpose. Some could be removed
 in the future. A version safe Redis client using this command should parse
 the output accordingly (i.e. handling gracefully missing fields, skipping
 unknown fields).
-
-@history
-
-* `>= 2.8.12`: Added unique client `id` field.
-* `>= 5.0`: Added optional `TYPE` filter.
-* `>= 6.2`: Added `laddr` field and the optional `ID` filter.

--- a/commands/client-pause.md
+++ b/commands/client-pause.md
@@ -38,8 +38,3 @@ to be static not just from the point of view of clients not being able to write,
 @return
 
 @simple-string-reply: The command returns OK or an error if the timeout is invalid.
-
-@history
-
-* `>= 3.2.10`: Client pause prevents client pause and key eviction as well.
-* `>= 6.2`: CLIENT PAUSE WRITE mode added along with the `mode` option.

--- a/commands/cluster-slots.md
+++ b/commands/cluster-slots.md
@@ -62,8 +62,4 @@ slot range reply.
       3) "58e6e48d41228013e5d9c1c37c5060693925e97e"
 ```
 
-@history
-
-* `>= 4.0`: Added node IDs.
-
 **Warning:** In future versions there could be more elements describing the node better. In general a client implementation should just rely on the fact that certain parameters are at fixed positions as specified, but more parameters may follow and should be ignored. Similarly a client library should try if possible to cope with the fact that older versions may just have the IP and port parameter.

--- a/commands/config-get.md
+++ b/commands/config-get.md
@@ -43,8 +43,3 @@ above is to the latest development version.
 @return
 
 The return type of the command is a @array-reply.
-
-@history
-
-* `>= 7.0.0`: Added the ability to pass multiple pattern parameters in one
-call.

--- a/commands/config-set.md
+++ b/commands/config-set.md
@@ -39,7 +39,3 @@ options are not mutually exclusive.
 
 @simple-string-reply: `OK` when the configuration was set properly.
 Otherwise an error is returned.
-
-@history
-
-* `>= 7.0.0`: Added the ability to set multiple parameters in one call.

--- a/commands/exists.md
+++ b/commands/exists.md
@@ -1,19 +1,10 @@
 Returns if `key` exists.
 
-Since Redis 3.0.3 it is possible to specify multiple keys instead of a single one. In such a case, it returns the total number of keys existing. Note that returning 1 or 0 for a single key is just a special case of the variadic usage, so the command is completely backward compatible.
-
 The user should be aware that if the same existing key is mentioned in the arguments multiple times, it will be counted multiple times. So if `somekey` exists, `EXISTS somekey somekey` will return 2.
 
 @return
 
-@integer-reply, specifically:
-
-* `1` if the key exists.
-* `0` if the key does not exist.
-
-Since Redis 3.0.3 the command accepts a variable number of keys and the return value is generalized:
-
-* The number of keys existing among the ones specified as arguments. Keys mentioned multiple times and existing are counted multiple times.
+@integer-reply, specifically the number of keys that exist from those specified as arguments.
 
 @examples
 

--- a/commands/expire.md
+++ b/commands/expire.md
@@ -81,10 +81,6 @@ EXPIRE mykey 10 NX
 TTL mykey
 ```
 
-@history
-
-* `>= 7.0`: Added options: `NX`, `XX`, `GT` and `LT`.
-
 ## Pattern: Navigation session
 
 Imagine you have a web service and you are interested in the latest N pages

--- a/commands/expire.md
+++ b/commands/expire.md
@@ -33,7 +33,7 @@ will be `del`, not `expired`).
 
 ## Options
 
-The `EXPIRE` command supports a set of options since Redis 7.0:
+The `EXPIRE` command supports a set of options:
 
 * `NX` -- Set expiry only when the key has no expiry
 * `XX` -- Set expiry only when the key has an existing expiry

--- a/commands/expireat.md
+++ b/commands/expireat.md
@@ -17,7 +17,7 @@ a given time in the future.
 
 ## Options
 
-The `EXPIREAT` command supports a set of options since Redis 7.0:
+The `EXPIREAT` command supports a set of options:
 
 * `NX` -- Set expiry only when the key has no expiry
 * `XX` -- Set expiry only when the key has an existing expiry

--- a/commands/expireat.md
+++ b/commands/expireat.md
@@ -42,7 +42,3 @@ EXISTS mykey
 EXPIREAT mykey 1293840000
 EXISTS mykey
 ```
-
-@history
-
-* `>= 7.0`: Added options: `NX`, `XX`, `GT` and `LT`.

--- a/commands/flushall.md
+++ b/commands/flushall.md
@@ -14,8 +14,3 @@ Note: an asynchronous `FLUSHALL` command only deletes keys that were present at 
 @return
 
 @simple-string-reply
-
-@history
-
-* `>= 4.0.0`: Added the `ASYNC` flushing mode modifier.
-* `>= 6.2.0`: Added the `!SYNC` flushing mode modifier and the **lazyfree-lazy-user-flush** configuration directive.

--- a/commands/geoadd.md
+++ b/commands/geoadd.md
@@ -46,10 +46,6 @@ However, in the worst case, the error may be up to 0.5%, so you may want to cons
 * When used without optional arguments, the number of elements added to the sorted set (excluding score updates).
 * If the `CH` option is specified, the number of elements that were changed (added or updated).
 
-@history
-
-* `>= 6.2`: Added the `CH`, `NX` and `XX` options.
-
 @examples
 
 ```cli

--- a/commands/georadius.md
+++ b/commands/georadius.md
@@ -1,7 +1,5 @@
 Return the members of a sorted set populated with geospatial information using `GEOADD`, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
 
-As per Redis 6.2.0, GEORADIUS command family are considered deprecated. Please prefer `GEOSEARCH` and `GEOSEARCHSTORE` in new code.
-
 This manual page also covers the `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO` variants (see the section below for more information).
 
 The common use case for this command is to retrieve geospatial items near a specified point not farther than a given amount of meters (or other units). This allows, for example, to suggest mobile users of an application nearby places.

--- a/commands/georadius.md
+++ b/commands/georadius.md
@@ -56,8 +56,6 @@ Since `GEORADIUS` and `GEORADIUSBYMEMBER` have a `STORE` and `STOREDIST` option 
 
 Breaking the compatibility with the past was considered but rejected, at least for Redis 4.0, so instead two read-only variants of the commands were added. They are exactly like the original commands but refuse the `STORE` and `STOREDIST` options. The two variants are called `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO`, and can safely be used in replicas.
 
-Both commands were introduced in Redis 3.2.10 and Redis 4.0.0, respectively.
-
 @examples
 
 ```cli

--- a/commands/georadius.md
+++ b/commands/georadius.md
@@ -58,11 +58,7 @@ Since `GEORADIUS` and `GEORADIUSBYMEMBER` have a `STORE` and `STOREDIST` option 
 
 Breaking the compatibility with the past was considered but rejected, at least for Redis 4.0, so instead two read-only variants of the commands were added. They are exactly like the original commands but refuse the `STORE` and `STOREDIST` options. The two variants are called `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO`, and can safely be used in replicas.
 
-Both commands were introduced in Redis 3.2.10 and Redis 4.0.0 respectively.
-
-@history
-
-* `>= 6.2`: Added the `ANY` option for `COUNT`.
+Both commands were introduced in Redis 3.2.10 and Redis 4.0.0, respectively.
 
 @examples
 

--- a/commands/georadiusbymember.md
+++ b/commands/georadiusbymember.md
@@ -1,8 +1,6 @@
 This command is exactly like `GEORADIUS` with the sole difference that instead
 of taking, as the center of the area to query, a longitude and latitude value, it takes the name of a member already existing inside the geospatial index represented by the sorted set.
 
-As per Redis 6.2.0, GEORADIUS command family are considered deprecated. Please prefer `GEOSEARCH` and `GEOSEARCHSTORE` in new code.
-
 The position of the specified member is used as the center of the query.
 
 Please check the example below and the `GEORADIUS` documentation for more information about the command and its options.

--- a/commands/getset.md
+++ b/commands/getset.md
@@ -17,8 +17,6 @@ GETSET mycounter "0"
 GET mycounter
 ```
 
-As per Redis 6.2, GETSET is considered deprecated. Please prefer `SET` with `GET` parameter in new code.
-
 @return
 
 @bulk-string-reply: the old value stored at `key`, or `nil` when `key` did not exist.

--- a/commands/hdel.md
+++ b/commands/hdel.md
@@ -8,14 +8,6 @@ If `key` does not exist, it is treated as an empty hash and this command returns
 @integer-reply: the number of fields that were removed from the hash, not
 including specified but non existing fields.
 
-@history
-
-*   `>= 2.4`: Accepts multiple `field` arguments.
-    Redis versions older than 2.4 can only remove a field per call.
-
-    To remove multiple fields from a hash in an atomic fashion in earlier
-    versions, use a `MULTI` / `EXEC` block.
-
 @examples
 
 ```cli

--- a/commands/hello.md
+++ b/commands/hello.md
@@ -59,7 +59,3 @@ protocol to the specified version and also accepts the following options:
 @return
 
 @array-reply: a list of server properties. The reply is a map instead of an array when RESP3 is selected. The command returns an error if the `protover` requested does not exist.
-
-@history
-
-* `>= 6.2`: `protover` made optional; when called without arguments the command reports the current connection's context.

--- a/commands/hmset.md
+++ b/commands/hmset.md
@@ -3,8 +3,6 @@ Sets the specified fields to their respective values in the hash stored at
 This command overwrites any specified fields already existing in the hash.
 If `key` does not exist, a new key holding a hash is created.
 
-As per Redis 4.0.0, HMSET is considered deprecated. Please prefer `HSET` in new code.
-
 @return
 
 @simple-string-reply

--- a/commands/hset.md
+++ b/commands/hset.md
@@ -2,8 +2,6 @@ Sets `field` in the hash stored at `key` to `value`.
 If `key` does not exist, a new key holding a hash is created.
 If `field` already exists in the hash, it is overwritten.
 
-As of Redis 4.0.0, HSET is variadic and allows for multiple `field`/`value` pairs.
-
 @return
 
 @integer-reply: The number of fields that were added.

--- a/commands/lpop.md
+++ b/commands/lpop.md
@@ -14,10 +14,6 @@ When called with the `count` argument:
 
 @array-reply: list of popped elements, or `nil` when `key` does not exist.
 
-@history
-
-* `>= 6.2`: Added the `count` argument.
-
 @examples
 
 ```cli

--- a/commands/lpush.md
+++ b/commands/lpush.md
@@ -14,12 +14,6 @@ containing `c` as first element, `b` as second element and `a` as third element.
 
 @integer-reply: the length of the list after the push operations.
 
-@history
-
-* `>= 2.4`: Accepts multiple `element` arguments.
-  In Redis versions older than 2.4 it was possible to push a single value per
-  command.
-
 @examples
 
 ```cli

--- a/commands/lpushx.md
+++ b/commands/lpushx.md
@@ -7,12 +7,6 @@ exist.
 
 @integer-reply: the length of the list after the push operation.
 
-@history
-
-* `>= 4.0`: Accepts multiple `element` arguments.
-  In Redis versions older than 4.0 it was possible to push a single value per
-  command.
-
 @examples
 
 ```cli

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -66,13 +66,6 @@ just a single key exists.
 * `!AUTH` -- Authenticate with the given password to the remote instance.
 * `AUTH2` -- Authenticate with the given username and password pair (Redis 6 or greater ACL auth style).
 
-@history
-
-* `>= 3.0.0`: Added the `!COPY` and `REPLACE` options.
-* `>= 3.0.6`: Added the `!KEYS` option.
-* `>= 4.0.7`: Added the `!AUTH` option.
-* `>= 6.0.0`: Added the `AUTH2` option.
-
 @return
 
 @simple-string-reply: The command returns OK on success, or `NOKEY` if no keys were

--- a/commands/monitor.md
+++ b/commands/monitor.md
@@ -84,9 +84,3 @@ Running more `MONITOR` clients will reduce throughput even more.
 
 **Non standard return value**, just dumps the received commands in an infinite
 flow.
-
-@history
-
-* `>= 6.0`: `AUTH` excluded from the command's output.
-* `>= 6.2`: `RESET` can be called to exit monitor mode.
-* `>= 6.2.4`: `AUTH`, `HELLO`, `EVAL`, `EVAL_RO`, `EVALSHA` and `EVALSHA_RO` included in the command's output.

--- a/commands/pexpire.md
+++ b/commands/pexpire.md
@@ -32,7 +32,3 @@ TTL mykey
 PEXPIRE mykey 1000 NX
 TTL mykey
 ```
-
-@history
-
-* `>= 7.0`: Added options: `NX`, `XX`, `GT` and `LT`.

--- a/commands/pexpireat.md
+++ b/commands/pexpireat.md
@@ -28,7 +28,3 @@ PEXPIREAT mykey 1555555555005
 TTL mykey
 PTTL mykey
 ```
-
-@history
-
-* `>= 7.0`: Added options: `NX`, `XX`, `GT` and `LT`.

--- a/commands/rename.md
+++ b/commands/rename.md
@@ -4,10 +4,6 @@ If `newkey` already exists it is overwritten, when this happens `RENAME` execute
 
 In Cluster mode, both `key` and `newkey` must be in the same **hash slot**, meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
 
-@history
-
-* `<= 3.2.0`: Before Redis 3.2.0, an error is returned if source and destination names are the same.
-
 @return
 
 @simple-string-reply

--- a/commands/renamenx.md
+++ b/commands/renamenx.md
@@ -3,11 +3,6 @@ It returns an error when `key` does not exist.
 
 In Cluster mode, both `key` and `newkey` must be in the same **hash slot**, meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
 
-
-@history
-
-* `<= 3.2.0`: Before Redis 3.2.0, an error is returned if source and destination names are the same.
-
 @return
 
 @integer-reply, specifically:

--- a/commands/restore.md
+++ b/commands/restore.md
@@ -6,17 +6,16 @@ expire time (in milliseconds) is set.
 
 If the `ABSTTL` modifier was used, `ttl` should represent an absolute
 [Unix timestamp][hewowu] (in milliseconds) in which the key will expire.
-(Redis 5.0 or greater).
 
 [hewowu]: http://en.wikipedia.org/wiki/Unix_time
 
 For eviction purposes, you may use the `IDLETIME` or `FREQ` modifiers. See
-`OBJECT` for more information (Redis 5.0 or greater).
+`OBJECT` for more information.
 
-`RESTORE` will return a "Target key name is busy" error when `key` already
-exists unless you use the `REPLACE` modifier (Redis 3.0 or greater).
+`!RESTORE` will return a "Target key name is busy" error when `key` already
+exists unless you use the `REPLACE` modifier.
 
-`RESTORE` checks the RDB version and data checksum.
+`!RESTORE` checks the RDB version and data checksum.
 If they don't match an error is returned.
 
 @return

--- a/commands/role.md
+++ b/commands/role.md
@@ -73,10 +73,6 @@ The sentinel output is composed of the following parts:
 
 @array-reply: where the first element is one of `master`, `slave`, `sentinel` and the additional elements are role-specific as illustrated above.
 
-@history
-
-* This command was introduced in the middle of a Redis stable release, specifically with Redis 2.8.12.
-
 @examples
 
 ```cli

--- a/commands/rpop.md
+++ b/commands/rpop.md
@@ -14,10 +14,6 @@ When called with the `count` argument:
 
 @array-reply: list of popped elements, or `nil` when `key` does not exist.
 
-@history
-
-* `>= 6.2`: Added the `count` argument.
-
 @examples
 
 ```cli

--- a/commands/rpoplpush.md
+++ b/commands/rpoplpush.md
@@ -13,9 +13,6 @@ If `source` and `destination` are the same, the operation is equivalent to
 removing the last element from the list and pushing it as first element of the
 list, so it can be considered as a list rotation command.
 
-As per Redis 6.2.0, RPOPLPUSH is considered deprecated. Please prefer `LMOVE` in
-new code.
-
 @return
 
 @bulk-string-reply: the element being popped and pushed.

--- a/commands/rpush.md
+++ b/commands/rpush.md
@@ -14,12 +14,6 @@ containing `a` as first element, `b` as second element and `c` as third element.
 
 @integer-reply: the length of the list after the push operation.
 
-@history
-
-* `>= 2.4`: Accepts multiple `element` arguments.
-  In Redis versions older than 2.4 it was possible to push a single value per
-  command.
-
 @examples
 
 ```cli

--- a/commands/rpushx.md
+++ b/commands/rpushx.md
@@ -7,12 +7,6 @@ exist.
 
 @integer-reply: the length of the list after the push operation.
 
-@history
-
-* `>= 4.0`: Accepts multiple `element` arguments.
-  In Redis versions older than 4.0 it was possible to push a single value per
-  command.
-
 @examples
 
 ```cli

--- a/commands/sadd.md
+++ b/commands/sadd.md
@@ -10,11 +10,6 @@ An error is returned when the value stored at `key` is not a set.
 @integer-reply: the number of elements that were added to the set, not including
 all the elements already present in the set.
 
-@history
-
-* `>= 2.4`: Accepts multiple `member` arguments.
-  Redis versions before 2.4 are only able to add a single member per call.
-
 @examples
 
 ```cli

--- a/commands/scan.md
+++ b/commands/scan.md
@@ -203,10 +203,6 @@ Also note that this behavior is specific of `SSCAN`, `HSCAN` and `ZSCAN`. `SCAN`
 * `HSCAN` array of elements contain two elements, a field and a value, for every returned element of the Hash.
 * `ZSCAN` array of elements contain two elements, a member and its associated score, for every returned element of the sorted set.
 
-@history
-
-  * `>= 6.0`: Supports the `TYPE` subcommand.
-
 ## Additional examples
 
 Iteration of a Hash value.

--- a/commands/scan.md
+++ b/commands/scan.md
@@ -142,7 +142,7 @@ As you can see most of the calls returned zero elements, but the last call where
 
 ## The TYPE option
 
-As of version 6.0 you can use this option to ask `SCAN` to only return objects that match a given `type`, allowing you to iterate through the database looking for keys of a specific type. The **TYPE** option is only available on the whole-database `SCAN`, not `HSCAN` or `ZSCAN` etc.
+You can use the `!TYPE` option to ask `SCAN` to only return objects that match a given `type`, allowing you to iterate through the database looking for keys of a specific type. The **TYPE** option is only available on the whole-database `SCAN`, not `HSCAN` or `ZSCAN` etc.
 
 The `type` argument is the same string name that the `TYPE` command returns. Note a quirk where some Redis types, such as GeoHashes, HyperLogLogs, Bitmaps, and Bitfields, may internally be implemented using other Redis types, such as a string or zset, so can't be distinguished from other keys of that same type by `SCAN`. For example, a ZSET and GEOHASH:
 

--- a/commands/script-flush.md
+++ b/commands/script-flush.md
@@ -13,7 +13,3 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 @return
 
 @simple-string-reply
-
-@history
-
-* `>= 6.2.0`: Added the `ASYNC` and `!SYNC` flushing mode modifiers, as well as the  **lazyfree-lazy-user-flush** configuration directive.

--- a/commands/set.md
+++ b/commands/set.md
@@ -29,14 +29,6 @@ If the command is issued with the `!GET` option, the above does not apply. It wi
 
 @nil-reply: `(nil)` if the key did not exist.
 
-
-@history
-
-* `>= 2.6.12`: Added the `EX`, `PX`, `NX` and `XX` options.
-* `>= 6.0`: Added the `KEEPTTL` option.
-* `>= 6.2`: Added the `!GET`, `EXAT` and `PXAT` option.
-* `>= 7.0`: Allowed the `NX` and `!GET` options to be used together.
-
 @examples
 
 ```cli

--- a/commands/slowlog-get.md
+++ b/commands/slowlog-get.md
@@ -24,7 +24,3 @@ restart will reset it.
 @reply
 
 @array-reply: a list of slow log entries.
-
-@history
-
-* `>= 4.0`: Added client IP address, port and name to the reply.

--- a/commands/sort.md
+++ b/commands/sort.md
@@ -1,7 +1,7 @@
 Returns or stores the elements contained in the [list][tdtl], [set][tdts] or
 [sorted set][tdtss] at `key`.
 
-Since Redis 7.0.0, there is also the `SORT_RO` read-only variant of this command.
+There is also the `SORT_RO` read-only variant of this command.
 
 By default, sorting is numeric and elements are compared by their value
 interpreted as double precision floating point number.

--- a/commands/sort_ro.md
+++ b/commands/sort_ro.md
@@ -2,7 +2,7 @@ Read-only variant of the `SORT` command. It is exactly like the original `SORT` 
 
 Since the original `SORT` has a `STORE` option it is technically flagged as a writing command in the Redis command table. For this reason read-only replicas in a Redis Cluster will redirect it to the master instance even if the connection is in read-only mode (see the `READONLY` command of Redis Cluster).
 
-Since Redis 7.0.0, the `SORT_RO` variant was introduced in order to allow `SORT` behavior in read-only replicas without breaking compatibility on command flags.
+The `SORT_RO` variant was introduced in order to allow `SORT` behavior in read-only replicas without breaking compatibility on command flags.
 
 See original `SORT` for more details.
 

--- a/commands/spop.md
+++ b/commands/spop.md
@@ -16,10 +16,6 @@ When called with the `count` argument:
 
 @array-reply: the removed members, or an empty array when `key` does not exist.
 
-@history
-
-* `>= 3.2`: Added the `count` argument.
-
 @examples
 
 ```cli

--- a/commands/srandmember.md
+++ b/commands/srandmember.md
@@ -21,10 +21,6 @@ SRANDMEMBER myset 2
 SRANDMEMBER myset -5
 ```
 
-@history
-
-* `>= 2.6.0`: Added the optional `count` argument.
-
 ## Specification of the behavior when count is passed
 
 When the `count` argument is a positive value this command behaves as follows:

--- a/commands/srem.md
+++ b/commands/srem.md
@@ -10,11 +10,6 @@ An error is returned when the value stored at `key` is not a set.
 @integer-reply: the number of members that were removed from the set, not
 including non existing members.
 
-@history
-
-* `>= 2.4`: Accepts multiple `member` arguments.
-  Redis versions older than 2.4 can only remove a set member per call.
-
 @examples
 
 ```cli

--- a/commands/subscribe.md
+++ b/commands/subscribe.md
@@ -3,7 +3,3 @@ Subscribes the client to the specified channels.
 Once the client enters the subscribed state it is not supposed to issue any
 other commands, except for additional `SUBSCRIBE`, `PSUBSCRIBE`, `UNSUBSCRIBE`,
 `PUNSUBSCRIBE`, `PING`, `RESET` and `QUIT` commands.
-
-@history
-
-* `>= 6.2`: `RESET` can be called to exit subscribed state.

--- a/commands/substr.md
+++ b/commands/substr.md
@@ -1,5 +1,3 @@
-**Note**: as of Redis 2.0, this command was renamed to `GETRANGE`.
-
 Returns the substring of the string value stored at `key`, determined by the
 offsets `start` and `end` (both are inclusive).
 Negative offsets can be used in order to provide an offset starting from the end

--- a/commands/xadd.md
+++ b/commands/xadd.md
@@ -85,11 +85,6 @@ specified by the user during insertion.
 The command returns a @nil-reply when used with the `NOMKSTREAM` option and the
 key doesn't exist.
 
-@history
-
-* `>= 6.2`: Added the `NOMKSTREAM` option, `MINID` trimming strategy and the `LIMIT` option.
-* `>= 7.0`: Added support for the `<ms>-*` explicit ID form.
-
 @examples
 
 ```cli

--- a/commands/xclaim.md
+++ b/commands/xclaim.md
@@ -6,7 +6,7 @@ command argument. Normally this is what happens:
 2. Some consumer A reads a message via `XREADGROUP` from a stream, in the context of that consumer group.
 3. As a side effect a pending message entry is created in the Pending Entries List (PEL) of the consumer group: it means the message was delivered to a given consumer, but it was not yet acknowledged via `XACK`.
 4. Then suddenly that consumer fails forever.
-5. Other consumers may inspect the list of pending messages, that are stale for quite some time, using the `XPENDING` command. In order to continue processing such messages, they use `XCLAIM` to acquire the ownership of the message and continue. As of Redis 6.2, consumers can use the `XAUTOCLAIM` command to automatically scan and claim stale pending messages.
+5. Other consumers may inspect the list of pending messages, that are stale for quite some time, using the `XPENDING` command. In order to continue processing such messages, they use `XCLAIM` to acquire the ownership of the message and continue. Consumers can also use the `XAUTOCLAIM` command to automatically scan and claim stale pending messages.
 
 This dynamic is clearly explained in the [Stream intro documentation](/topics/streams-intro).
 

--- a/commands/xpending.md
+++ b/commands/xpending.md
@@ -135,7 +135,3 @@ command.
 The command returns data in different format depending on the way it is
 called, as previously explained in this page. However the reply is always
 an array of items.
-
-@history
-
-* `>= 6.2.0`: Added the `IDLE` option and exclusive range intervals.

--- a/commands/xpending.md
+++ b/commands/xpending.md
@@ -107,7 +107,7 @@ a single consumer.
 
 ## Idle time filter
 
-Since version 6.2 it is possible to filter entries by their idle-time,
+It is also possible to filter pending stream entries by their idle-time,
 given in milliseconds (useful for `XCLAIM`ing entries that have not been
 processed for some time):
 

--- a/commands/xrange.md
+++ b/commands/xrange.md
@@ -210,10 +210,6 @@ The returned entries are complete, that means that the ID and all the fields
 they are composed are returned. Moreover, the entries are returned with
 their fields and values in the exact same order as `XADD` added them.
 
-@history
-
-* `>= 6.2` Added exclusive ranges.
-
 @examples
 
 ```cli

--- a/commands/xrevrange.md
+++ b/commands/xrevrange.md
@@ -24,10 +24,6 @@ The returned entries are complete, that means that the ID and all the fields
 they are composed are returned. Moreover the entries are returned with
 their fields and values in the exact same order as `XADD` added them.
 
-@history
-
-* `>= 6.2` Added exclusive ranges.
-
 @examples
 
 ```cli

--- a/commands/xtrim.md
+++ b/commands/xtrim.md
@@ -48,10 +48,6 @@ Specifying the value 0 as `count` disables the limiting mechanism entirely.
 
 @integer-reply: The number of entries deleted from the stream.
 
-@history
-
-* `>= 6.2`: Added the `MINID` trimming strategy and the `LIMIT` option.
-
 @examples
 
 ```cli

--- a/commands/zadd.md
+++ b/commands/zadd.md
@@ -69,14 +69,6 @@ If the `INCR` option is specified, the return value will be @bulk-string-reply:
 
 * The new score of `member` (a double precision floating point number) represented as string, or `nil` if the operation was aborted (when called with either the `XX` or the `NX` option).
 
-@history
-
-* `>= 2.4`: Accepts multiple elements.
-  In Redis versions older than 2.4 it was possible to add or update a single
-  member per call.
-* `>= 3.0.2`: Added the `XX`, `NX`, `CH` and `INCR` options.
-* `>= 6.2`: Added the `GT` and `LT` options.
-
 @examples
 
 ```cli

--- a/commands/zrange.md
+++ b/commands/zrange.md
@@ -82,10 +82,6 @@ The binary nature of the comparison allows to use sorted sets as a general purpo
 @array-reply: list of elements in the specified range (optionally with
 their scores, in case the `WITHSCORES` option is given).
 
-@history
-
-* `>= 6.2`: Added the `REV`, `BYSCORE`, `BYLEX` and `LIMIT` options.
-
 @examples
 
 ```cli

--- a/commands/zrangebylex.md
+++ b/commands/zrangebylex.md
@@ -4,8 +4,6 @@ If the elements in the sorted set have different scores, the returned elements a
 
 The elements are considered to be ordered from lower to higher strings as compared byte-by-byte using the `memcmp()` C function. Longer strings are considered greater than shorter strings if the common part is identical.
 
-As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYLEX` argument in new code.
-
 The optional `LIMIT` argument can be used to only get a range of the matching
 elements (similar to _SELECT LIMIT offset, count_ in SQL). A negative `count`
 returns all elements from the `offset`.

--- a/commands/zrangebyscore.md
+++ b/commands/zrangebyscore.md
@@ -6,8 +6,6 @@ The elements having the same score are returned in lexicographical order (this
 follows from a property of the sorted set implementation in Redis and does not
 involve further computation).
 
-As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYSCORE` argument in new code.
-
 The optional `LIMIT` argument can be used to only get a range of the matching
 elements (similar to _SELECT LIMIT offset, count_ in SQL). A negative `count`
 returns all elements from the `offset`.

--- a/commands/zrem.md
+++ b/commands/zrem.md
@@ -10,12 +10,6 @@ An error is returned when `key` exists and does not hold a sorted set.
 * The number of members removed from the sorted set, not including non existing
   members.
 
-@history
-
-* `>= 2.4`: Accepts multiple elements.
-  In Redis versions older than 2.4 it was possible to remove a single member per
-  call.
-
 @examples
 
 ```cli

--- a/commands/zremrangebyscore.md
+++ b/commands/zremrangebyscore.md
@@ -1,9 +1,6 @@
 Removes all elements in the sorted set stored at `key` with a score between
 `min` and `max` (inclusive).
 
-Since version 2.1.6, `min` and `max` can be exclusive, following the syntax of
-`ZRANGEBYSCORE`.
-
 @return
 
 @integer-reply: the number of elements removed.

--- a/commands/zrevrange.md
+++ b/commands/zrevrange.md
@@ -4,8 +4,6 @@ Descending lexicographical order is used for elements with equal score.
 
 Apart from the reversed ordering, `ZREVRANGE` is similar to `ZRANGE`.
 
-As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `REV` argument in new code.
-
 @return
 
 @array-reply: list of elements in the specified range (optionally with

--- a/commands/zrevrangebylex.md
+++ b/commands/zrevrangebylex.md
@@ -2,8 +2,6 @@ When all the elements in a sorted set are inserted with the same score, in order
 
 Apart from the reversed ordering, `ZREVRANGEBYLEX` is similar to `ZRANGEBYLEX`.
 
-As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYLEX` and `REV` arguments in new code.
-
 @return
 
 @array-reply: list of elements in the specified score range.

--- a/commands/zrevrangebyscore.md
+++ b/commands/zrevrangebyscore.md
@@ -9,8 +9,6 @@ order.
 Apart from the reversed ordering, `ZREVRANGEBYSCORE` is similar to
 `ZRANGEBYSCORE`.
 
-As per Redis 6.2.0, this command is considered deprecated. Please prefer using the `ZRANGE` command with the `BYSCORE` and `REV` arguments in new code.
-
 @return
 
 @array-reply: list of elements in the specified score range (optionally


### PR DESCRIPTION
As these were moved into Redis core (pending fixes included in https://github.com/redis/redis/pull/10016).

Related to https://github.com/redis/redis-io/pull/260