### PR TITLE
Fix client_recent_max_input_buffer/client_recent_max_output_buffer fi…

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -84,10 +84,8 @@ Here is the meaning of all fields in the **clients** section:
 *   `maxclients`: The value of the `maxclients` configuration directive. This is
     the upper limit for the sum of `connected_clients`, `connected_slaves` and
     `cluster_connections`.
-*   `client_longest_output_list`: Longest output list among current client
-     connections
-*   `client_biggest_input_buf`: Biggest input buffer among current client
-     connections
+*   `client_recent_max_input_buffer`: Biggest input buffer among current client connections
+*   `client_recent_max_output_buffer`: Biggest output buffer among current client connections
 *   `blocked_clients`: Number of clients pending on a blocking call (`BLPOP`,
      `BRPOP`, `BRPOPLPUSH`, `BLMOVE`, `BZPOPMIN`, `BZPOPMAX`)
 *   `tracking_clients`: Number of clients being tracked (`CLIENT TRACKING`)


### PR DESCRIPTION
After a few updates, the field has been renamed:

In https://github.com/redis/redis/commit/ea3a20c5d05869a498d037f67f92fd05287f9428,
client_longest_output_list -> client_max_input_buffer
client_biggest_input_buf -> client_max_output_buffer

And in https://github.com/redis/redis/commit/be88c0b16a53f5763d8fc1ae683f99ee39b0d68e
client_max_input_buffer -> client_recent_max_input_buffer
client_max_output_buffer -> client_recent_max_output_buffer