### PR TITLE
Add multi-mem and resp in CLIENT LIST

### DIFF
--- a/commands/client-list.md
+++ b/commands/client-list.md
@@ -15,11 +15,11 @@ The `ID` filter only returns entries for clients with IDs matching the `client-i
 
 Here is the meaning of the fields:
 
-* `id`: an unique 64-bit client ID.
-* `name`: the name set by the client with `CLIENT SETNAME`
+* `id`: a unique 64-bit client ID
 * `addr`: address/port of the client
 * `laddr`: address/port of local address client connected to (bind address)
 * `fd`: file descriptor corresponding to the socket
+* `name`: the name set by the client with `CLIENT SETNAME`
 * `age`: total duration of the connection in seconds
 * `idle`: idle time of the connection in seconds
 * `flags`: client flags (see below)
@@ -29,15 +29,17 @@ Here is the meaning of the fields:
 * `multi`: number of commands in a MULTI/EXEC context
 * `qbuf`: query buffer length (0 means no query pending)
 * `qbuf-free`: free space of the query buffer (0 means the buffer is full)
+* `argv-mem`: incomplete arguments for the next command (already extracted from query buffer)
+* `multi-mem`: memory is used up by buffered multi commands. Added in Redis 7.0
 * `obl`: output buffer length
 * `oll`: output list length (replies are queued in this list when the buffer is full)
 * `omem`: output buffer memory usage
+* `tot-mem`: total memory consumed by this client in its various buffers
 * `events`: file descriptor events (see below)
 * `cmd`: last command played
-* `argv-mem`: incomplete arguments for the next command (already extracted from query buffer)
-* `tot-mem`: total memory consumed by this client in its various buffers
-* `redir`: client id of current client tracking redirection
 * `user`: the authenticated username of the client
+* `redir`: client id of current client tracking redirection
+* `resp`: client RESP protocol version. Added in Redis 7.0
 
 The client flags can be a combination of:
 


### PR DESCRIPTION
multi-mem: added in redis/redis#8687
resp: added in redis/redis#9508

Also adjust the order of fields to better match the output

The current output format is (redis unstable branch):
```
id=3 addr=127.0.0.1:50188 laddr=127.0.0.1:6379 fd=8 name= age=7 idle=0
flags=N db=0 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=20448 argv-mem=10
multi-mem=0 obl=0 oll=0 omem=0 tot-mem=40986 events=r cmd=client|list
user=default redir=-1 resp=2
```