### PR TITLE
Remove recommended from  radix as too few stars

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -110,7 +110,6 @@
     "repository": "https://github.com/mediocregopher/radix",
     "description": "MIT licensed Redis client which supports pipelining, pooling, redis cluster, scripting, pub/sub, scanning, and more.",
     "authors": ["fzzbt", "mediocre_gopher"],
-    "recommended": true,
     "active": true
   },
 


### PR DESCRIPTION
There is too few stars on the client module `radix`, is it strange to recommend it? 🤔 