### PR TITLE
Fix shutdown_in_milliseconds wrong name in INFO

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -73,7 +73,7 @@ Here is the meaning of all fields in the **server** section:
 *   `executable`: The path to the server's executable
 *   `config_file`: The path to the config file
 *   `io_threads_active`: Flag indicating if I/O threads are active
-*   `shutdown_in_seconds`: The maximum time remaining for replicas to catch up the replication before completing the shutdown sequence.
+*   `shutdown_in_milliseconds`: The maximum time remaining for replicas to catch up the replication before completing the shutdown sequence.
     This field is only present during shutdown.
 
 Here is the meaning of all fields in the **clients** section:


### PR DESCRIPTION
#1748 shutdown_in_milliseconds. Added in https://github.com/redis/redis/pull/9872