### PR TITLE
Added comment that `aof_rewrite_buffer_length` was removed in 7.0

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -224,7 +224,7 @@ If AOF is activated, these additional fields will be added:
 *   `aof_pending_rewrite`: Flag indicating an AOF rewrite operation
      will be scheduled once the on-going RDB save is complete.
 *   `aof_buffer_length`: Size of the AOF buffer
-*   `aof_rewrite_buffer_length`: Size of the AOF rewrite buffer
+*   `aof_rewrite_buffer_length`: Size of the AOF rewrite buffer. Note this field was removed in Redis 7.0
 *   `aof_pending_bio_fsync`: Number of fsync pending jobs in background I/O
      queue
 *   `aof_delayed_fsync`: Delayed fsync counter

--- a/commands/memory-stats.md
+++ b/commands/memory-stats.md
@@ -18,7 +18,7 @@ values. The following metrics are reported:
      and query buffers, connection contexts)
 *   `aof.buffer`: The summed size in bytes of the current and rewrite AOF
      buffers (see `INFO`'s `aof_buffer_length` and `aof_rewrite_buffer_length`,
-     respectively)
+     respectively). Note that `aof_rewrite_buffer_length` is not included since Redis 7.0
 *    `lua.caches`: the summed size in bytes of the overheads of the Lua scripts'
      caches
 *   `dbXXX`: For each of the server's databases, the overheads of the main and

--- a/commands/memory-stats.md
+++ b/commands/memory-stats.md
@@ -16,10 +16,8 @@ values. The following metrics are reported:
      and query buffers, connection contexts)
 *   `clients.normal`: The total size in bytes of all clients overheads (output
      and query buffers, connection contexts)
-*   `aof.buffer`: The summed size in bytes of the current and rewrite AOF
-     buffers (see `INFO`'s `aof_buffer_length` and `aof_rewrite_buffer_length`,
-     respectively). Note that `aof_rewrite_buffer_length` is not included since Redis 7.0
-*    `lua.caches`: the summed size in bytes of the overheads of the Lua scripts'
+*   `aof.buffer`: The summed size in bytes of AOF related buffers.
+*   `lua.caches`: the summed size in bytes of the overheads of the Lua scripts'
      caches
 *   `dbXXX`: For each of the server's databases, the overheads of the main and
      expiry dictionaries (`overhead.hashtable.main` and


### PR DESCRIPTION
#1748 aof_rewrite_buffer_length, removed in https://github.com/redis/redis/pull/9788