### PR TITLE
Fix wrong server_time_usec INFO field name

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -64,7 +64,7 @@ Here is the meaning of all fields in the **server** section:
 *   `run_id`: Random value identifying the Redis server (to be used by Sentinel
      and Cluster)
 *   `tcp_port`: TCP/IP listen port
-*   `server_time_in_usec`: Epoch-based system time with microsecond precision
+*   `server_time_usec`: Epoch-based system time with microsecond precision
 *   `uptime_in_seconds`: Number of seconds since Redis server start
 *   `uptime_in_days`: Same value expressed in days
 *   `hz`: The server's current frequency setting


### PR DESCRIPTION
`server_time_usec`, added in https://github.com/redis/redis/pull/8132
now in redis-doc is `server_time_in_usec`, added in #1455

#1748 server_time_usec
