### PR TITLE
fix multipart aof backup doc

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -212,6 +212,8 @@ Here is the meaning of all fields in the **persistence** section:
 *   `module_fork_in_progress`: Flag indicating a module fork is on-going
 *   `module_fork_last_cow_size`: The size in bytes of copy-on-write memory
      during the last module fork operation
+*   `aof_rewrites`: Number of AOF rewrites performed since startup
+*   `rdb_saves`: Number of RDB snapshots performed since startup
 
 `rdb_changes_since_last_save` refers to the number of operations that produced
 some kind of changes in the dataset since the last time either `SAVE` or

--- a/topics/persistence.md
+++ b/topics/persistence.md
@@ -335,7 +335,7 @@ You may use this script as a basis for your own backup script, or it might suffi
 
 Running the script is as simple as `./aof_backup.sh mybackup.tar.gz`.
 
-Following is a low level description of the script works:
+Following is a description of the script works:
 
 1. Verify the server isn't performing a rewrite.
 2. Create hard links to files in the `appenddirname` directory.
@@ -345,7 +345,7 @@ Following is a low level description of the script works:
 5. Delete the hard links.
 
 Prior to version 7.0.0 backing up the AOF file can be done simply by copying the aof file (like backing up the RDB snapshot). The file may lack the final part
-but Redis will still be able to load it (see the previous sections about truncated AOF files).
+but Redis will still be able to load it (see the previous sections about [truncated AOF files](#what-should-i-do-if-my-aof-gets-truncated)).
 
 
 Disaster recovery


### PR DESCRIPTION
Fix multipart aof backup doc to use `aof_backup.sh` script for safe aof backups since v7.
See https://github.com/redis/redis/pull/10178