### PR TITLE
topics/pubsub: add RESET to allowed commands for subscribed client

### DIFF
--- a/topics/pubsub.md
+++ b/topics/pubsub.md
@@ -27,8 +27,7 @@ The replies to subscription and unsubscription operations are sent in
 the form of messages, so that the client can just read a coherent
 stream of messages where the first element indicates the type of
 message. The commands that are allowed in the context of a subscribed
-client are `SUBSCRIBE`, `SSUBSCRIBE`, `SUNSUBSCRIBE`, `PSUBSCRIBE`,
-`UNSUBSCRIBE`, `PUNSUBSCRIBE`, `PING`, `RESET`, and `QUIT`.
+client are `SUBSCRIBE`, `SSUBSCRIBE`, `SUNSUBSCRIBE`, `PSUBSCRIBE`, `UNSUBSCRIBE`, `PUNSUBSCRIBE`, `PING`, `RESET`, and `QUIT`.
 
 Please note that `redis-cli` will not accept any commands once in
 subscribed mode and can only quit the mode with `Ctrl-C`.

--- a/topics/pubsub.md
+++ b/topics/pubsub.md
@@ -27,8 +27,8 @@ The replies to subscription and unsubscription operations are sent in
 the form of messages, so that the client can just read a coherent
 stream of messages where the first element indicates the type of
 message. The commands that are allowed in the context of a subscribed
-client are `SUBSCRIBE`, `SSUBSCRIBE`, `SUNSUBSCRIBE`, `PSUBSCRIBE`, `UNSUBSCRIBE`, `PUNSUBSCRIBE`,
-`PING` and `QUIT`.
+client are `SUBSCRIBE`, `SSUBSCRIBE`, `SUNSUBSCRIBE`, `PSUBSCRIBE`,
+`UNSUBSCRIBE`, `PUNSUBSCRIBE`, `PING`, `RESET`, and `QUIT`.
 
 Please note that `redis-cli` will not accept any commands once in
 subscribed mode and can only quit the mode with `Ctrl-C`.


### PR DESCRIPTION
This change adds RESET to the list of allowed commands a client can
issue in a subscribed context. After this change the list of commands
will be consistent with the list specified for [SUBSCRIBE][subscribe],
and also the allowed commands as specified by the implementation.

https://github.com/redis/redis/blob/a43b6922d1e37d60acf63484b7057299c9bf584d/src/server.c#L3626-L3637

[subscribe]: https://redis.io/commands/subscribe