### PR TITLE
Error message method name now does not contain 'f_'

### DIFF
--- a/commands/eval_ro.md
+++ b/commands/eval_ro.md
@@ -15,5 +15,5 @@ OK
 "Hello"
 
 > EVAL_RO "return redis.call('DEL', KEYS[1])" 1 mykey
-(error) ERR Error running script (call to f_359f69785f876b7f3f60597d81534f3d6c403284): @user_script:1: @user_script: 1: Write commands are not allowed from read-only scripts
+(error) ERR Error running script (call to b0d697da25b13e49157b2c214a4033546aba2104): @user_script:1: @user_script: 1: Write commands are not allowed from read-only scripts.
 ```


### PR DESCRIPTION
Redis7.0 RC1
```
127.0.0.1:6379> EVAL_RO "return redis.call('DEL', KEYS[1])" 1 mykey
(error) ERR Error running script (call to b0d697da25b13e49157b2c214a4033546aba2104): @user_script:1: @user_script: 1: Write commands are not allowed from read-only scripts.
```

In Redis7.0 FUNCTION changes, now the error reply does not contain 'f_'.

https://github.com/redis/redis/blob/f4ecc799c87fa504b375afc17a7f8302789254b5/src/eval.c#L506-L514
```
    char *lua_cur_script = funcname + 2;           ----------- here
    dictEntry *de = dictFind(lctx.lua_scripts, lua_cur_script);
    luaScript *l = dictGetVal(de);
    int ro = c->cmd->proc == evalRoCommand || c->cmd->proc == evalShaRoCommand;

    scriptRunCtx rctx;
    if (scriptPrepareForRun(&rctx, lctx.lua_client, c, lua_cur_script, l->flags, ro) != C_OK) {
        return;
    }
```

https://github.com/redis/redis/blob/unstable/src/script.c#L178
```
/* Prepare the given run ctx for execution */
int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *caller, const char *funcname, uint64_t script_flags, int ro) {
    ...
    run_ctx->funcname = funcname;          ------------ here
```

https://github.com/redis/redis/blob/f4ecc799c87fa504b375afc17a7f8302789254b5/src/script_lua.c#L1412-L1415
```
    if (err) {
        addReplyErrorFormat(c,"Error running script (call to %s): %s\n",
                run_ctx->funcname, lua_tostring(lua,-1));        ---------- here
        lua_pop(lua,1); /* Consume the Lua reply and remove error handler. */
```