### PR TITLE
Change word to reduce ambiguity in 'LRU cache' page sentence.

### DIFF
--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -88,7 +88,7 @@ Approximated LRU algorithm
 
 Redis LRU algorithm is not an exact implementation. This means that Redis is
 not able to pick the *best candidate* for eviction, that is, the access that
-was accessed the most in the past. Instead it will try to run an approximation
+was accessed the furthest in the past. Instead it will try to run an approximation
 of the LRU algorithm, by sampling a small number of keys, and evicting the
 one that is the best (with the oldest access time) among the sampled keys.
 


### PR DESCRIPTION
"most" is a generic qualifier, so the sentence under revision may currently be read in at least two distinct ways:

1.  "the access that was **accessed the most** in the past"
2. "the access that was accessed the **most in the past**"

The first interpretation refers to a key that was most frequently accessed in some unspecified past period.

The second interpretation refers to a key that was accessed earlier than any other candidate key. This is, I think, the correct interpretation. 

"furthest" is not as generic a qualifier, and can't really be bound to the _amount_ of accesses, so the first (and incorrect) interpretation is avoided. "Furthest" is a distance qualifier, applicable to both space and time. In this case, time.