### PR TITLE
Change zrange parameters names

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -15665,11 +15665,11 @@
                 "key_spec_index": 0
             },
             {
-                "name": "min",
+                "name": "start",
                 "type": "string"
             },
             {
-                "name": "max",
+                "name": "stop",
                 "type": "string"
             },
             {


### PR DESCRIPTION
In #1736 there were introduced new names of parameters 'min', 'max' (now 'start', 'stop'), but command in header wasn't updated