### PR TITLE
Add parameter part for  PUBSUB SHARDNUMSUB command 

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -9898,6 +9898,14 @@
             "@slow"
         ],
         "arity": -2,
+        "arguments": [
+            {
+                "name": "channel",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
         "command_flags": [
             "pubsub",
             "loading",


### PR DESCRIPTION
PUBSUB SHARDNUMSUB command misses the following parameter part:

"arguments": [
{
"name": "channel",
"type": "string",
"optional": true,
"multiple": true
}