### PR TITLE
Fix cluster-keyslot example

### DIFF
--- a/commands/cluster-keyslot.md
+++ b/commands/cluster-keyslot.md
@@ -10,7 +10,7 @@ Example use cases for this command:
 
 ```
 > CLUSTER KEYSLOT somekey
-11058
+(integer) 11058
 > CLUSTER KEYSLOT foo{hash_tag}
 (integer) 2515
 > CLUSTER KEYSLOT bar{hash_tag}


### PR DESCRIPTION
Add `(integer)` to be more accurate and consistent