### PR TITLE
Fix the wrong CLUSTER SET-CONFIG-EPOCH command name

### DIFF
--- a/commands/cluster-set-config-epoch.md
+++ b/commands/cluster-set-config-epoch.md
@@ -16,7 +16,7 @@ the exception, only to make sure that whatever happens, two more
 nodes eventually always move away from the state of having the same
 configuration epoch.
 
-So, using `CONFIG SET-CONFIG-EPOCH`, when a new cluster is created, we can
+So, using `CLUSTER SET-CONFIG-EPOCH`, when a new cluster is created, we can
 assign a different progressive configuration epoch to each node before
 joining the cluster together.
 

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -1165,7 +1165,7 @@ If there are any set of nodes with the same `configEpoch`, all the nodes but the
 
 This mechanism also guarantees that after a fresh cluster is created, all
 nodes start with a different `configEpoch` (even if this is not actually
-used) since `redis-cli` makes sure to use `CONFIG SET-CONFIG-EPOCH` at startup.
+used) since `redis-cli` makes sure to use `CLUSTER SET-CONFIG-EPOCH` at startup.
 However if for some reason a node is left misconfigured, it will update
 its configuration to a different configuration epoch automatically.
 


### PR DESCRIPTION
I am sure there is no `CONFIG SET-CONFIG-EPOCH`.