### PR TITLE
"are" -> "as". Fix word use in spec.

### DIFF
--- a/topics/protocol.md
+++ b/topics/protocol.md
@@ -195,7 +195,7 @@ RESP Arrays
 
 Clients send commands to the Redis server using RESP Arrays. Similarly
 certain Redis commands returning collections of elements to the client
-use RESP Arrays as reply type. An example is the `LRANGE` command that
+use RESP Arrays as the reply type. An example is the `LRANGE` command that
 returns elements of a list.
 
 RESP Arrays are sent using the following format:

--- a/topics/protocol.md
+++ b/topics/protocol.md
@@ -195,7 +195,7 @@ RESP Arrays
 
 Clients send commands to the Redis server using RESP Arrays. Similarly
 certain Redis commands returning collections of elements to the client
-use RESP Arrays are reply type. An example is the `LRANGE` command that
+use RESP Arrays as reply type. An example is the `LRANGE` command that
 returns elements of a list.
 
 RESP Arrays are sent using the following format:


### PR DESCRIPTION
Mirror of https://github.com/redis/redis-specifications/pull/4. I'm not sure which is the source of truth.

> Was making a toy Redis server in Java (https://app.codecrafters.io/courses/redis) which had me reading the spec at [redis.io/topics/protocol](https://redis.io/topics/protocol).
> 
> This sentence didn't make sense to me, so I've edited in what I think is the intended meaning.

