### PR TITLE
Added pub-sub alias

### DIFF
--- a/docs/manual/pubsub.md
+++ b/docs/manual/pubsub.md
@@ -5,6 +5,7 @@ weight: 1
 description: How to use pub/sub channels in Redis
 aliases:
   - /topics/pubsub
+  - /docs/manual/pub-sub
 ---
 
 `SUBSCRIBE`, `UNSUBSCRIBE` and `PUBLISH`


### PR DESCRIPTION
The Pub/Sub link on the [About](https://redis.io/docs/about/) page redirected to /docs/manual/pub-sub instead of /docs/manual/pubsub, which caused a 404. This new alias should fix the 404.