### PR TITLE
Add link alias on About Page

### DIFF
--- a/docs/manual/sentinel.md
+++ b/docs/manual/sentinel.md
@@ -3,8 +3,10 @@ title: "High availability with Redis Sentinel"
 linkTitle: "High availability with Sentinel"
 weight: 1
 description: High availability for non-clustered Redis
-aliases:
-  - /topics/sentinel
+aliases: [
+    /topics/sentinel,
+    /manual/high-availability,
+]
 ---
 
 Redis Sentinel provides high availability for Redis when not using [Redis Cluster](/docs/manual/scaling). 

--- a/docs/manual/sentinel.md
+++ b/docs/manual/sentinel.md
@@ -5,7 +5,7 @@ weight: 1
 description: High availability for non-clustered Redis
 aliases: [
     /topics/sentinel,
-    /manual/high-availability,
+    /docs/manual/high-availability,
 ]
 ---
 


### PR DESCRIPTION
On [About](https://redis.io/docs/about/) page, I clicked [Automatic failover](https://redis.io/topics/sentinel) but redirected to /docs/manual/high-availability/ page.
So, I added alias.
It will help to fix the "404 Page not found".