### PR TITLE
Added behavior change history section to commands

### DIFF
--- a/commands/client-pause.md
+++ b/commands/client-pause.md
@@ -38,3 +38,7 @@ to be static not just from the point of view of clients not being able to write,
 @return
 
 @simple-string-reply: The command returns OK or an error if the timeout is invalid.
+
+## Behavior change history
+
+*   `>= 3.2.0`: Client pause prevents client pause and key eviction as well.

--- a/commands/cluster-slots.md
+++ b/commands/cluster-slots.md
@@ -86,3 +86,7 @@ If a cluster instance has non-contiguous slots (e.g. 1-400,900,1800-6000) then m
 **Warning:** In future versions there could be more elements describing the node better.
 In general a client implementation should just rely on the fact that certain parameters are at fixed positions as specified, but more parameters may follow and should be ignored.
 Similarly a client library should try if possible to cope with the fact that older versions may just have the primary endpoint and port parameter.
+
+## Behavior change history
+
+*   `>= 7.0.0`: Added support for hostnames and unknown endpoints in first field of node response.

--- a/commands/flushall.md
+++ b/commands/flushall.md
@@ -14,3 +14,7 @@ Note: an asynchronous `FLUSHALL` command only deletes keys that were present at 
 @return
 
 @simple-string-reply
+
+## Behavior change history
+
+*   `>= 6.2.0`: Default flush behavior now configurable by the **lazyfree-lazy-user-flush** configuration directive. 

--- a/commands/flushdb.md
+++ b/commands/flushdb.md
@@ -14,3 +14,7 @@ Note: an asynchronous `FLUSHDB` command only deletes keys that were present at t
 @return
 
 @simple-string-reply
+
+## Behavior change history
+
+*   `>= 6.2.0`: Default flush behavior now configurable by the **lazyfree-lazy-user-flush** configuration directive. 

--- a/commands/monitor.md
+++ b/commands/monitor.md
@@ -84,3 +84,9 @@ Running more `MONITOR` clients will reduce throughput even more.
 
 **Non standard return value**, just dumps the received commands in an infinite
 flow.
+
+## Behavior change history
+
+*   `>= 6.0.0`: `AUTH` excluded from the command's output.
+*   `>= 6.2.0`: "`RESET` can be called to exit monitor mode.
+*   `>= 6.2.4`: "`AUTH`, `HELLO`, `EVAL`, `EVAL_RO`, `EVALSHA` and `EVALSHA_RO` included in the command's output.

--- a/commands/rename.md
+++ b/commands/rename.md
@@ -15,3 +15,7 @@ SET mykey "Hello"
 RENAME mykey myotherkey
 GET myotherkey
 ```
+
+## Behavior change history
+
+*   `>= 3.2.0`: The command no longer returns an error when source and destination names are the same.

--- a/commands/script-flush.md
+++ b/commands/script-flush.md
@@ -13,3 +13,7 @@ For more information about `EVAL` scripts please refer to [Introduction to Eval 
 @return
 
 @simple-string-reply
+
+## Behavior change history
+
+*   `>= 6.2.0`: Default flush behavior now configurable by the **lazyfree-lazy-user-flush** configuration directive. 

--- a/commands/shutdown.md
+++ b/commands/shutdown.md
@@ -67,3 +67,7 @@ To minimize the risk of data loss in such setups, it's advised to trigger a manu
 @simple-string-reply: `OK` if `ABORT` was specified and shutdown was aborted.
 On successful shutdown, nothing is returned since the server quits and the connection is closed.
 On failure, an error is returned.
+
+## Behavior change history
+
+*   `>= 7.0.0`: Introduced waiting for lagging replicas before exiting.

--- a/commands/subscribe.md
+++ b/commands/subscribe.md
@@ -3,3 +3,7 @@ Subscribes the client to the specified channels.
 Once the client enters the subscribed state it is not supposed to issue any
 other commands, except for additional `SUBSCRIBE`, `SSUBSCRIBE`, `PSUBSCRIBE`, `UNSUBSCRIBE`, `SUNSUBSCRIBE`, 
 `PUNSUBSCRIBE`, `PING`, `RESET` and `QUIT` commands.
+
+## Behavior change history
+
+*   `>= 6.2.0`: `RESET` can be called to exit subscribed state.


### PR DESCRIPTION
Added a section for behavior change history as a replacement for https://github.com/redis/redis/pull/10398.