### PR TITLE
Add the deprecated_since field in command args of COMMAND DOCS

### DIFF
--- a/commands/command-docs.md
+++ b/commands/command-docs.md
@@ -7,7 +7,7 @@ The reply includes a map for each returned command.
 The following keys may be included in the mapped reply:
 
 * **summary:** short command description.
-* **since:** the Redis version that added the command.
+* **since:** the Redis/module version that added the command.
 * **group:** the functional group to which the command belongs.
   Possible values are:
   - _bitmap_
@@ -29,12 +29,12 @@ The following keys may be included in the mapped reply:
   - _string_
   - _transactions_
 * **complexity:** a short explanation about the command's time complexity.
-* **doc-flags:** an array of documentation flags.
+* **doc_flags:** an array of documentation flags.
   Possible values are:
   - _deprecated:_ the command is deprecated.
   - _syscmd:_ a system command that isn't meant to be called by users.
-* **deprecated-since:** the Redis version that deprecated the command.
-* **replaced-by:** the alternative for a deprecated command.
+* **deprecated_since:** the Redis/module version that deprecated the command.
+* **replaced_by:** the alternative for a deprecated command.
 * **history:** an array of historical notes describing changes to the command's behavior or arguments.
   Each entry is an array itself, made up of two elements:
   1. The Redis version that the entry applies to.

--- a/docs/reference/command-arguments.md
+++ b/docs/reference/command-arguments.md
@@ -30,11 +30,12 @@ Every element in the _arguments_ array is a map with the following fields:
     This type enables choice among several nested arguments (see the `XADD` example below).
   - **block:** the argument is a container for nested arguments.
     This type enables grouping arguments and applying a property (such as _optional_) to all (see the `XADD` example below).
-* **key-spec-index:** this value is available for every argument of the _key_ type.
+* **key_spec_index:** this value is available for every argument of the _key_ type.
   It is a 0-based index of the specification in the command's [key specifications][tr] that corresponds to the argument.
 * **token**: a constant literal that precedes the argument (user input) itself.
 * **summary:** a short description of the argument.
-* **since:** the debut Redis version of the argument.
+* **since:** the debut Redis/module version of the argument.
+* **deprecated_since:** the Redis/module version that deprecated the command.
 * **flags:** an array of argument flags.
   Possible flags are:
   - **optional**: denotes that the argument is optional (for example, the _GET_ clause of the  `SET` command).

--- a/docs/reference/key-specs.md
+++ b/docs/reference/key-specs.md
@@ -206,13 +206,13 @@ When this flag is present, it means that the key specification flags cover all p
      2) 1) RW
         2) access
         3) update
-     3) "begin-search"
+     3) "begin_search"
      4) 1) "type"
         2) "index"
         3) "spec"
         4) 1) "index"
            2) (integer) 1
-     5) "find-keys"
+     5) "find_keys"
      6) 1) "type"
         2) "range"
         3) "spec"
@@ -230,13 +230,13 @@ When this flag is present, it means that the key specification flags cover all p
   1) 1) "flags"
      2) 1) RO
         2) access
-     3) "begin-search"
+     3) "begin_search"
      4) 1) "type"
         2) "index"
         3) "spec"
         4) 1) "index"
            2) (integer) 1
-     5) "find-keys"
+     5) "find_keys"
      6) 1) "type"
         2) "keynum"
         3) "spec"


### PR DESCRIPTION
Other changes:
1. Both since/deprecated_since can rperesent either the Redis version or a module version
2. Use underscore instead of hyphens in some of COMMAND's variants (the code itself uses underscores, we need to update the docs)