### PR TITLE
Multi channel subscription behaviour for SSUBSCRIBE.

### DIFF
--- a/commands/ssubscribe.md
+++ b/commands/ssubscribe.md
@@ -1,7 +1,9 @@
 Subscribes the client to the specified shard channels.
 
 In a Redis cluster, shard channels are assigned to slots by the same algorithm used to assign keys to slots. 
-Client(s) can subscribe to a node covering a slot (primary/replica) to receive the messages published.
+Client(s) can subscribe to a node covering a slot (primary/replica) to receive the messages published. 
+All the specified shard channels needs to belong to a single slot to subscribe in a given `SSUBSCRIBE` call,
+A client can subscribe to channels across different slots over separate `SSUBSCRIBE` call.
 
 For more information about sharded Pub/Sub, see [Sharded Pub/Sub](pubsub#sharded-pubsub).
 


### PR DESCRIPTION
Update multi channel subscription behaviour for `SSUBSCRIBE`.

ref [10599](https://github.com/redis/redis/issues/10599)