### PR TITLE
Add coredis library to python clients

### DIFF
--- a/clients/python/github.com/alisaifee/coredis.json
+++ b/clients/python/github.com/alisaifee/coredis.json
@@ -1,0 +1,4 @@
+{
+  "name": "coredis",
+  "description": "Async redis client with support for redis server, cluster & sentinel"
+}


### PR DESCRIPTION
# Details 
[coredis](https://github.com/alisaifee/coredis) was forked from [aredis](https://github.com/NoneGG/aredis) as the latter had become unmaintained since 2020.

- coredis [2.x](https://github.com/alisaifee/coredis/tree/2.x) refreshed aredis with support for python 3.10 and brought in some outstanding pull requests/bug fixes.
- coredis [3.x](https://coredis.readthedocs.org/en/latest) has diverged from aredis and is no longer API compatible. It adds support for redis 7, type annotations, RESP3 support among others.

As a follow up I would also recommend marking aredis as unmaintained.