### PR TITLE
Added allow-cross-slot-keys flag

### DIFF
--- a/docs/manual/programmability/eval-intro.md
+++ b/docs/manual/programmability/eval-intro.md
@@ -435,4 +435,6 @@ return x
 Note that as soon as Redis sees the `#!` comment, it'll treat the script as if it declares flags, even if no flags are defined,
 it still has a different set of defaults compared to a script without a `#!` line.
 
+Another difference is that scripts without `#!` can run commands that access keys belonging to different cluster hash slots, but ones with `#!` inherit the default flags, so they cannot.
+
 Please refer to [Script flags](lua-api#script_flags) to learn about the various scripts and the defaults.

--- a/docs/manual/programmability/lua-api.md
+++ b/docs/manual/programmability/lua-api.md
@@ -446,7 +446,7 @@ By default, Redis assumes that all scripts read and write data.
 This results in the following behavior:
 
 1. They can read and write data.
-1. They can run in cluster mode.
+1. They can run in cluster mode, and are not able to run commands accessing keys of different hash slots.
 1. Execution against a stale replica is denied to avoid inconsistent reads.
 1. Execution under low memory is denied to avoid exceeding the configured threshold.
 

--- a/docs/manual/programmability/lua-api.md
+++ b/docs/manual/programmability/lua-api.md
@@ -479,6 +479,15 @@ You can use the following flags and instruct the server to treat the scripts' ex
     Redis allows scripts to be executed both in standalone and cluster modes.
     Setting this flag prevents executing the script against nodes in the cluster.
 
+* `allow-cross-slot-keys`: The flag that allows a script to access keys from multiple slots.
+
+    Redis typically prevents any single command from accessing keys that hash to multiple slots.
+    This flag allows scripts to break this rule and access keys within the script that access multiple slots.
+    Declared keys to the script are still always required to hash to a single slot.
+    Accessing keys from multiple slots is discouraged as applications should be designed to only access keys from a single slot at a time, allowing slots to move between Redis servers.
+    
+    This flag has no effect when cluster mode is disabled.
+
 Please refer to [Function Flags](functions-intro#function-flags) and [Eval Flags](eval-intro#eval-flags) for a detailed example.
 
 ### <a name="redis.redis_version"></a> `redis.REDIS_VERSION`


### PR DESCRIPTION
Adds documentation for a new lua flag, `allow-cross-slot-keys` which is implemented here: https://github.com/redis/redis/pull/10615