### PR TITLE
Partial fix for REDISIO-186: redis-doc broken links

### DIFF
--- a/clients/crystal/github.com/vladfaust/mini_redis.json
+++ b/clients/crystal/github.com/vladfaust/mini_redis.json
@@ -1,7 +1,6 @@
 {
     "name": "mini_redis",
     "description": "A light-weight low-level Redis client for Crystal",
-    "homepage": "http://github.vladfaust.com/mini_redis/",
     "twitter": [
         "vladfaust"
     ]

--- a/clients/php/github.com/Shumkov/Rediska.json
+++ b/clients/php/github.com/Shumkov/Rediska.json
@@ -1,7 +1,6 @@
 {
     "name": "Rediska",
     "description": "A Redis client.",
-    "homepage": "http://rediska.geometria-lab.net",
     "twitter": [
         "shumkov"
     ]

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -11,7 +11,7 @@ aliases:
 Redis is **open source software** released under the terms of the **three clause BSD license**. Most of the Redis source code was written and is copyrighted by Salvatore Sanfilippo and Pieter Noordhuis. A list of other contributors can be found in the git history.
 
 The Redis trademark and logo are owned by Redis Ltd. and can be
-used in accordance with the [Redis Trademark Guidelines](/docs/project/trademark).
+used in accordance with the [Redis Trademark Guidelines](/docs/about/trademark).
 
 ## Three clause BSD license
 
@@ -51,9 +51,9 @@ Redis uses source code from third parties. All this code contains a BSD or BSD-c
 
 * Redis uses the `sha1.c` file that is copyright by Steve Reid and released under the **public domain**. This file is extremely popular and used among open source and proprietary code.
 
-* When compiled on Linux Redis uses the [Jemalloc allocator](http://www.canonware.com/jemalloc/), that is copyright by Jason Evans, Mozilla Foundation and Facebook, Inc and is released under the **two-clause BSD license**.
+* When compiled on Linux, Redis uses the Jemalloc allocator, which is copyright by Jason Evans, Mozilla Foundation and Facebook, Inc and released under the **two-clause BSD license**.
 
-* Inside Jemalloc the file `pprof` is copyright Google Inc and released under the **three-clause BSD license**.
+* Inside Jemalloc, the file `pprof` is copyright by Google Inc and released under the **three-clause BSD license**.
 
 * Inside Jemalloc the files `inttypes.h`, `stdbool.h`, `stdint.h`, `strings.h` under the `msvc_compat` directory are copyright Alexander Chemeris and released under the **three-clause BSD license**.
 

--- a/docs/about/sponsors.md
+++ b/docs/about/sponsors.md
@@ -14,9 +14,9 @@ Past sponsorships:
 * The [Shuttleworth Foundation](http://www.shuttleworthfoundation.org) has donated 5000 USD to the Redis project in form of a flash grant.
 * From May 2013 to June 2015, the work [Salvatore Sanfilippo](http://twitter.com/antirez) did to develop Redis was sponsored by [Pivotal](http://gopivotal.com).
 * Before May 2013, the project was sponsored by VMware with the work of [Salvatore Sanfilippo](http://twitter.com/antirez) and [Pieter Noordhuis](http://twitter.com/pnoordhuis).
-* [VMware](http://vmware.com) and later [Pivotal](http://pivotal.io) provided a 24 GB RAM workstation for Salvatore to run the [Redis CI test](http://ci.redis.io) and other long running tests. Later, Salvatore equipped the server with an SSD drive in order to test in the same hardware with rotating and flash drives.
+* [VMware](http://vmware.com) and later [Pivotal](http://pivotal.io) provided a 24 GB RAM workstation for Salvatore to run the Redis CI test and other long running tests. Later, Salvatore equipped the server with an SSD drive in order to test in the same hardware with rotating and flash drives.
 * [Linode](http://linode.com), in January 2010, provided virtual machines for Redis testing in a virtualized environment.
-* [Slicehost](http://slicehost.com), January 2010, provided Virtual Machines for Redis testing in a virtualized environment.
+* Slicehost, January 2010, provided Virtual Machines for Redis testing in a virtualized environment.
 * [Citrusbyte](http://citrusbyte.com), in December 2009, contributed part of Virtual Memory implementation.
 * [Hitmeister](http://www.hitmeister.de/), in December 2009, contributed part of Redis Cluster.
 * [Engine Yard](http://engineyard.com), in December 2009, contributed blocking POP (BLPOP) and part of the Virtual Memory implementation.
@@ -25,14 +25,13 @@ Also thanks to the following people or organizations that donated to the Project
 
 * Emil Vladev
 * [Brad Jasper](http://bradjasper.com/)
-* [Mrkris](http://www.mrkris.com/)
 
 The Redis community is grateful to [Redis Ltd.](http://redis.com), [Pivotal](http://gopivotal.com), [VMware](http://vmware.com) and to the other companies and people who have donated to the Redis project. Thank you.
 
 ## redis.io
 
 [Citrusbyte](https://citrusbyte.com) sponsored the creation of the official
-Redis logo (designed by [Carlos Prioglio](http://carlosprioglio.com)) and
+Redis logo (designed by Carlos Prioglio) and
 transferred its copyright to Salvatore Sanfilippo.
 
 They also sponsored the initial implementation of this site by

--- a/docs/manual/data-types/_index.md
+++ b/docs/manual/data-types/_index.md
@@ -152,4 +152,4 @@ A Redis stream is a data structure that acts like an append-only log. Streams ar
 
 Redis provides geospatial indexes, which are useful for finding locations within a given geographic radius. You can add locations to a geospatial index using the [GEOADD](/commands/geoadd) command. You then search for locations within a given radius using the [GEORADIUS](/commands/georadius) command.
 
-See the [complete geospatial index command reference](commands/?group=geo) for all of the details.
+See the [complete geospatial index command reference](https://redis.io/commands/?group=geo) for all of the details.

--- a/docs/manual/eviction.md
+++ b/docs/manual/eviction.md
@@ -106,10 +106,7 @@ What is important about the Redis LRU algorithm is that you **are able to tune**
 
 The reason Redis does not use a true LRU implementation is because it
 costs more memory. However, the approximation is virtually equivalent for an
-application using Redis. The following is a graphical comparison of how
-the LRU approximation used by Redis compares with true LRU.
-
-![LRU comparison](https://redis.io/images/redisdoc/lru_comparison.png)
+application using Redis.
 
 The test to generate the above graphs filled a Redis server with a given number of keys. The keys were accessed from the first to the last. The first keys are the best candidates for eviction using an LRU algorithm. Later more 50% of keys are added, in order to force half of the old keys to be evicted.
 

--- a/docs/manual/pipelining.md
+++ b/docs/manual/pipelining.md
@@ -88,13 +88,9 @@ The context switch is a huge speed penalty.
 
 When pipelining is used, many commands are usually read with a single `read()`
 system call, and multiple replies are delivered with a single `write()` system
-call.
-Because of this, the number of total queries performed per second
+call. Consequently, the number of total queries performed per second
 initially increases almost linearly with longer pipelines, and eventually
-reaches 10 times the baseline obtained without pipelining, as you can
-see from the following graph:
-
-![Pipeline size and IOPs](https://redis.io/images/redisdoc/pipeline_iops.png)
+reaches 10 times the baseline obtained without pipelining.
 
 ## A real world code example
 

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -30,5 +30,5 @@ releases that included important fixes.
 
 ### List of known Linux related bugs affecting Redis.
 
-* Ubuntu 10.04 and 10.10 have serious bugs (especially 10.10) that cause slow downs if not just instance hangs. Please move away from the default kernels shipped with this distributions. [Link to 10.04 bug](https://blog.librato.com/posts/2011/5/16/ec2-users-should-be-cautious-when-booting-ubuntu-1004-amis). [Link to 10.10 bug](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/666211). Both bugs were reported many times in the context of EC2 instances, but other users confirmed that also native servers are affected (at least by one of the two).
-* Certain versions of the Xen hypervisor are known to have very bad fork() performances. See [the latency page](/topics/latency) for more information.
+* Ubuntu 10.04 and 10.10 contain [bugs](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/666211) that can cause performance issues. The default kernels shipped with these distributions are not recommended. Bugs were reported as having affected EC2 instances, but some users also cited server impact.
+* Certain versions of the Xen hypervisor report poor fork() performance. See [the latency page](/topics/latency) for more information.

--- a/docs/reference/internals/internals-rediseventlib.md
+++ b/docs/reference/internals/internals-rediseventlib.md
@@ -27,7 +27,7 @@ Q: I guess I have to do many such non-blocking operations on the socket to see w
 A: Yes. That is what an event library does for you. Now you get it.
 
 Q: How do Event Libraries do what they do?<br/>
-A: They use the operating system's [polling](http://www.devshed.com/c/a/BrainDump/Linux-Files-and-the-Event-Poll-Interface/) facility along with timers.
+A: They use the operating system's polling facility along with timers.
 
 Q: So are there any open source event libraries that do what you just described? <br/>
 A: Yes. `libevent` and `libev` are two such event libraries that I can recall off the top of my head.

--- a/docs/reference/patterns/indexes.md
+++ b/docs/reference/patterns/indexes.md
@@ -547,14 +547,11 @@ sometimes used. Here we'll describe a different way to index data into
 multiple dimensions, using a representation trick that allows us to perform
 the query in a very efficient way using Redis lexicographical ranges.
 
-Let's start by visualizing the problem. In this picture we have points
-in the space, which represent our data samples, where `x` and `y` are
+Let's say we have points in the space, which represent our data samples, where `x` and `y` are
 our coordinates. Both variables max value is 400.
 
-The blue box in the picture represents our query. We want all the points
+We want all the points
 where `x` is between 50 and 100, and where `y` is between 100 and 300.
-
-![Points in the space](https://redis.io/images/redisdoc/2idx_0.png)
 
 In order to represent data that makes these kinds of queries fast to perform,
 we start by padding our numbers with 0. So for example imagine we want to
@@ -591,9 +588,7 @@ We obtain a range which is lexicographically continuous:
 What this maps to is to a square representing all values where the `x`
 variable is between 70 and 79, and the `y` variable is between 200 and 209.
 We can write random points in this interval, in order to identify this
-specific area:
-
-![Small area](https://redis.io/images/redisdoc/2idx_1.png)
+specific area.
 
 So the above lexicographic query allows us to easily query for points in
 a specific square in the picture. However the square may be too small for
@@ -606,11 +601,9 @@ range:
 
 This time the range represents all the points where `x` is between 0 and 99
 and `y` is between 200 and 299. Drawing random points in this interval
-shows us this larger area:
+shows us this larger area.
 
-![Large area](https://redis.io/images/redisdoc/2idx_2.png)
-
-Oops now our area is ways too big for our query, and still our search box is
+So now our area is too big for our query, and still our search box is
 not completely included. We need more granularity, but we can easily obtain
 it by representing our numbers in binary form. This time, when we replace
 digits instead of getting squares which are ten times bigger, we get squares

--- a/docs/reference/patterns/twitter-clone.md
+++ b/docs/reference/patterns/twitter-clone.md
@@ -14,15 +14,15 @@ applications using Redis as their main store, so the goal of the article today
 is to be a tutorial for Redis newcomers. You'll learn how to design a simple
 data layout using Redis, and how to apply different data structures.
 
-Our Twitter clone, called [Retwis](http://retwis.antirez.com), is structurally simple, has very good performance, and can be distributed among any number of web and Redis servers with little efforts. You can find the source code [here](http://code.google.com/p/redis/downloads/list).
+Our Twitter clone, called Retwis, is structurally simple, has very good performance, and can be distributed among any number of web and Redis servers with little efforts. You can find the source code [here](http://code.google.com/p/redis/downloads/list).
 
 I used PHP for the example since it can be read by everybody. The same (or better) results can be obtained using Ruby, Python, Erlang, and so on.
 A few clones exist (however not all the clones use the same data layout as the
 current version of this tutorial, so please, stick with the official PHP
 implementation for the sake of following the article better).
 
-* [Retwis-RB](http://retwisrb.danlucraft.com/) is a port of Retwis to Ruby and Sinatra written by Daniel Lucraft! Full source code is included of course, and a link to its Git repository appears in the footer of this article. The rest of this article targets PHP, but Ruby programmers can also check the Retwis-RB source code since it's conceptually very similar.
-* [Retwis-J](http://retwisj.cloudfoundry.com/) is a port of Retwis to Java, using the Spring Data Framework, written by [Costin Leau](http://twitter.com/costinl). Its source code can be found on [GitHub](https://github.com/SpringSource/spring-data-keyvalue-examples), and there is comprehensive documentation available at [springsource.org](http://j.mp/eo6z6I).
+* [Retwis-RB](https://github.com/danlucraft/retwis-rb) is a port of Retwis to Ruby and Sinatra written by Daniel Lucraft.
+* [Retwis-J](https://docs.spring.io/spring-data/data-keyvalue/examples/retwisj/current/) is a port of Retwis to Java, using the Spring Data Framework, written by [Costin Leau](http://twitter.com/costinl). Its source code can be found on [GitHub](https://github.com/SpringSource/spring-data-keyvalue-examples), and there is comprehensive documentation available at [springsource.org](http://j.mp/eo6z6I).
 
 What is a key-value store?
 ---


### PR DESCRIPTION
This PR fixes the redis-doc part of the broken links as described in [REDISIO-186](https://redislabs.atlassian.net/browse/REDISIO-186).