### PR TITLE
Add documentation documenting read-only scripts

### DIFF
--- a/commands/eval_ro.md
+++ b/commands/eval_ro.md
@@ -1,6 +1,6 @@
 This is a read-only variant of the `EVAL` command that cannot execute commands that modify data.
 
-For more information about when to use this command vs `EVAL`, please refer to [Read-only scripts](/topics/eval-intro#Read-only_scripts).
+For more information about when to use this command vs `EVAL`, please refer to [Read-only scripts](/docs/manual/programmability/#Read-only_scripts).
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).
 

--- a/commands/eval_ro.md
+++ b/commands/eval_ro.md
@@ -1,7 +1,6 @@
 This is a read-only variant of the `EVAL` command that cannot execute commands that modify data.
 
-Unlike `EVAL`, scripts executed with this command can always be killed and never affect the replication stream.
-Because the script can only read data, this command can always be executed on a master or a replica.
+For more information about when to use this command vs `EVAL`, please refer to [Read-only scripts](/topics/eval-intro#Read-only_scripts).
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).
 

--- a/commands/evalsha_ro.md
+++ b/commands/evalsha_ro.md
@@ -1,6 +1,5 @@
 This is a read-only variant of the `EVALSHA` command that cannot execute commands that modify data.
 
-Unlike `EVALSHA`, scripts executed with this command can always be killed and never affect the replication stream.
-Because it can only read data, this command can always be executed on a master or a replica.
+For more information about when to use this command vs `EVALSHA`, please refer to [Read-only scripts](/topics/eval-intro#Read-only_scripts).
 
 For more information about `EVALSHA` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).

--- a/commands/evalsha_ro.md
+++ b/commands/evalsha_ro.md
@@ -1,5 +1,5 @@
 This is a read-only variant of the `EVALSHA` command that cannot execute commands that modify data.
 
-For more information about when to use this command vs `EVALSHA`, please refer to [Read-only scripts](/topics/eval-intro#Read-only_scripts).
+For more information about when to use this command vs `EVALSHA`, please refer to [Read-only scripts](/docs/manual/programmability/#Read-only_scripts).
 
 For more information about `EVALSHA` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).

--- a/commands/fcall_ro.md
+++ b/commands/fcall_ro.md
@@ -1,5 +1,5 @@
 This is a read-only variant of the `FCALL` command that cannot execute commands that modify data.
 
-For more information about when to use this command vs `FCALL`, please refer to [Read-only scripts](/topics/eval-intro#Read-only_scripts).
+For more information about when to use this command vs `FCALL`, please refer to [Read-only scripts](/docs/manual/programmability/#Read-only_scripts).
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).

--- a/commands/fcall_ro.md
+++ b/commands/fcall_ro.md
@@ -1,3 +1,5 @@
 This is a read-only variant of the `FCALL` command that cannot execute commands that modify data.
 
+For more information about when to use this command vs `FCALL`, please refer to [Read-only scripts](/topics/eval-intro#Read-only_scripts).
+
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).

--- a/docs/manual/programmability/_index.md
+++ b/docs/manual/programmability/_index.md
@@ -59,6 +59,17 @@ Note that the potential downside of this blocking approach is that executing slo
 It is not hard to create fast scripts because scripting's overhead is very low.
 However, if you intend to use a slow script in your application, be aware that all other clients are blocked and can't execute any command while it is running.
 
+## Read-only scripts
+
+A read-only script is a script that only executes commands that don't modify any keys within Redis.
+Read-only scripts are useful because they can always be executed on replicas and can always be killed by the `SCRIPT KILL` command. 
+Read-only scripts can be executed either by adding the `no-writes` flag to the script or by executing the script with one of the read-only script command variants: `EVAL_RO`, `EVALSHA_RO`, or `FCALL_RO`.
+In addition to the benefits provided by all read-only scripts, the read-only script commands are also not blocked during write pauses, such as those that occur during coordinated failovers, and can be used to configure an ACL user to only be able to execute read-only scripts.
+Many clients also better support routing the read-only script commands to replicas for applications that want to use replicas for read scaling.
+
+The recommended approach is to use the standard scripting commands with the `no-writes` flag unless you need one of the previously mentioned features.
+In future versions of Redis, this extra functionality may become available to all scripts that declare the `no-writes` flag.
+
 ## Sandboxed script context
 
 Redis places the engine that executes user scripts inside a sandbox.

--- a/docs/manual/programmability/eval-intro.md
+++ b/docs/manual/programmability/eval-intro.md
@@ -441,9 +441,10 @@ Please refer to [Script flags](/topics/lua-api#script_flags) to learn about the 
 
 ## Read-only scripts
 A read-only script is a script that only executes commands that don't modify any keys within Redis.
-Read-only scripts are useful because they can always be executed on replicas and can always be killed by the script kill command. 
-Read-only scripts can be executed either by: adding the `no-writes` flag to the script or by executing the script with one of the read-only script command variants: `EVAL_RO`, `EVALSHA_RO`, and `FCALL_RO`.
-In addition to the benefits provided by all read-only scripts, the read-only script commands are also not blocked during write pauses, such as those that occur during coordinated failovers, and can be be used to configure an ACL user to only be able to execute read-only scripts.
+Read-only scripts are useful because they can always be executed on replicas and can always be killed by the `SCRIPT KILL` command. 
+Read-only scripts can be executed either by adding the `no-writes` flag to the script or by executing the script with one of the read-only script command variants: `EVAL_RO`, `EVALSHA_RO`, or `FCALL_RO`.
+In addition to the benefits provided by all read-only scripts, the read-only script commands are also not blocked during write pauses, such as those that occur during coordinated failovers, and can be used to configure an ACL user to only be able to execute read-only scripts.
 Many clients also better support routing the read-only script commands to replicas for applications that want to use replicas for read scaling.
 
-In future versions of Redis, these additional benefits may become available to all scripts that declare the `no-writes` flag.
+The recommended approach is to use the standard scripting commands with the `no-writes` flag unless you need one of the previously mentioned features.
+In future versions of Redis, this extra functionality may become available to all scripts that declare the `no-writes` flag.

--- a/docs/manual/programmability/eval-intro.md
+++ b/docs/manual/programmability/eval-intro.md
@@ -438,3 +438,12 @@ it still has a different set of defaults compared to a script without a `#!` lin
 Another difference is that scripts without `#!` can run commands that access keys belonging to different cluster hash slots, but ones with `#!` inherit the default flags, so they cannot.
 
 Please refer to [Script flags](/topics/lua-api#script_flags) to learn about the various scripts and the defaults.
+
+## Read-only scripts
+A read-only script is a script that only executes commands that don't modify any keys within Redis.
+Read-only scripts are useful because they can always be executed on replicas and can always be killed by the script kill command. 
+Read-only scripts can be executed either by: adding the `no-writes` flag to the script or by executing the script with one of the read-only script command variants: `EVAL_RO`, `EVALSHA_RO`, and `FCALL_RO`.
+In addition to the benefits provided by all read-only scripts, the read-only script commands are also not blocked during write pauses, such as those that occur during coordinated failovers, and can be be used to configure an ACL user to only be able to execute read-only scripts.
+Many clients also better support routing the read-only script commands to replicas for applications that want to use replicas for read scaling.
+
+In future versions of Redis, these additional benefits may become available to all scripts that declare the `no-writes` flag.

--- a/docs/manual/programmability/eval-intro.md
+++ b/docs/manual/programmability/eval-intro.md
@@ -438,13 +438,3 @@ it still has a different set of defaults compared to a script without a `#!` lin
 Another difference is that scripts without `#!` can run commands that access keys belonging to different cluster hash slots, but ones with `#!` inherit the default flags, so they cannot.
 
 Please refer to [Script flags](/topics/lua-api#script_flags) to learn about the various scripts and the defaults.
-
-## Read-only scripts
-A read-only script is a script that only executes commands that don't modify any keys within Redis.
-Read-only scripts are useful because they can always be executed on replicas and can always be killed by the `SCRIPT KILL` command. 
-Read-only scripts can be executed either by adding the `no-writes` flag to the script or by executing the script with one of the read-only script command variants: `EVAL_RO`, `EVALSHA_RO`, or `FCALL_RO`.
-In addition to the benefits provided by all read-only scripts, the read-only script commands are also not blocked during write pauses, such as those that occur during coordinated failovers, and can be used to configure an ACL user to only be able to execute read-only scripts.
-Many clients also better support routing the read-only script commands to replicas for applications that want to use replicas for read scaling.
-
-The recommended approach is to use the standard scripting commands with the `no-writes` flag unless you need one of the previously mentioned features.
-In future versions of Redis, this extra functionality may become available to all scripts that declare the `no-writes` flag.


### PR DESCRIPTION
Based on discussion from https://github.com/redis/redis/pull/10728#issuecomment-1127313929, want to better define when to use `EVAL` et. al vs `EVAL_RO` et al. 