### PR TITLE
Remove extra title in key-specs page

### DIFF
--- a/docs/reference/key-specs.md
+++ b/docs/reference/key-specs.md
@@ -7,8 +7,6 @@
    - /topics/key-specs
 ---
 
-# Command key specifications
-
 Many of the commands in Redis accept key names as input arguments.
 The 9th element in the reply of `COMMAND` (and `COMMAND INFO`) is an array that consists of the command's key specifications.
 


### PR DESCRIPTION
We do have a `title: "Command key specifications"` in the front.
So this one will render an extra title, remove it.