### PR TITLE
fix BITFIELD_RO command synopsis

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -736,6 +736,7 @@
                 "type": "block",
                 "token": "GET",
                 "multiple": true,
+                "multiple_token": true,
                 "arguments": [
                     {
                         "name": "encoding",


### PR DESCRIPTION
Current documentation only states a single GET tocken is needed
which is not true.
marking the command with multiple_token