### PR TITLE
Remove obsolete python clients

### DIFF
--- a/clients/python/github.com/Grokzen/redis-py-cluster.json
+++ b/clients/python/github.com/Grokzen/redis-py-cluster.json
@@ -1,6 +1,6 @@
 {
     "name": "redis-py-cluster",
-    "description": "Python cluster client for the official redis cluster. Redis 3.0+.",
+    "description": "Adds cluster support to redis-py < 4.1.0. Obsolete for 4.1.0 and above.",
     "twitter": [
         "grokzen"
     ]

--- a/clients/python/github.com/Grokzen/redis-py-cluster.json
+++ b/clients/python/github.com/Grokzen/redis-py-cluster.json
@@ -1,7 +1,0 @@
-{
-    "name": "redis-py-cluster",
-    "description": "Python cluster client for the official redis cluster. Redis 3.0+.",
-    "twitter": [
-        "grokzen"
-    ]
-}

--- a/clients/python/github.com/Grokzen/redis-py-cluster.json
+++ b/clients/python/github.com/Grokzen/redis-py-cluster.json
@@ -1,0 +1,7 @@
+{
+    "name": "redis-py-cluster",
+    "description": "Python cluster client for the official redis cluster. Redis 3.0+.",
+    "twitter": [
+        "grokzen"
+    ]
+}

--- a/clients/python/github.com/NoneGG/aredis.json
+++ b/clients/python/github.com/NoneGG/aredis.json
@@ -1,4 +1,0 @@
-{
-    "name": "aredis",
-    "description": "An efficient and user-friendly async redis client ported from redis-py."
-}

--- a/clients/python/github.com/aio-libs/aioredis.json
+++ b/clients/python/github.com/aio-libs/aioredis.json
@@ -1,5 +1,0 @@
-{
-    "name": "aioredis",
-    "description": "Asyncio (PEP 3156) Redis client",
-    "homepage": "http://aioredis.readthedocs.org/"
-}


### PR DESCRIPTION
# Description
Follow up from #1885 to remove obsoleted python clients from documentation:

- [x] aredis: unmaintained
- [x] aioredis: absorbed by redis-py
- [ ] ~~redis-py-cluster: absorbed by redis-py~~ (See discussion in comments)