### PR TITLE
Fix typo in RESP protocol example

### DIFF
--- a/docs/reference/protocol-spec.md
+++ b/docs/reference/protocol-spec.md
@@ -215,7 +215,7 @@ integers and a bulk string can be encoded as follows:
     :2\r\n
     :3\r\n
     :4\r\n
-    $6\r\n
+    $5\r\n
     hello\r\n
 
 (The reply was split into multiple lines for clarity).


### PR DESCRIPTION
While writing a RESP parser in Rust, I copied some of the examples from the docs to use in my tests. 

When adding validation to my code I noticed a bulk string had the incorrect length.