### PR TITLE
Fix link to eviction policy docs

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -77,7 +77,7 @@ with an error to write commands (but will continue to accept read-only
 commands).
 
 You can also configure Redis to evict keys when the max memory limit
-is reached. See the [eviction policy docs] for more information on this.
+is reached. See the [eviction policy docs](/docs/manual/eviction/) for more information on this.
 
 ## Background saving fails with a fork() error on Linux?
 


### PR DESCRIPTION
Current page contains an incomplete markdown link.  Add link to https://redis.io/docs/manual/eviction/