### PR TITLE
Add redis-client and redis-cluster-client to Ruby clients

### DIFF
--- a/clients/ruby/github.com/redis-rb/redis-client.json
+++ b/clients/ruby/github.com/redis-rb/redis-client.json
@@ -1,0 +1,4 @@
+{
+    "name": "redis-client",
+    "description": "Simple low level client for Redis 6+"
+}

--- a/clients/ruby/github.com/redis-rb/redis-cluster-client.json
+++ b/clients/ruby/github.com/redis-rb/redis-cluster-client.json
@@ -1,0 +1,4 @@
+{
+    "name": "redis-cluster-client",
+    "description": "A simple client for Redis 6+ cluster"
+}

--- a/clients/ruby/github.com/redis/redis-clustering.json
+++ b/clients/ruby/github.com/redis/redis-clustering.json
@@ -1,0 +1,4 @@
+{
+    "name": "redis-clustering",
+    "description": "A Ruby client that tries to match Redis' Cluster API one-to-one, while still providing an idiomatic interface."
+}


### PR DESCRIPTION
Hello,

We implemented two clients for Ruby. They were made by the same maintainers as [the redis gem](https://rubygems.org/gems/redis). They are geared toward Redis version 6 or later.

* https://github.com/redis/redis-rb/issues/1070
* https://rubygems.org/gems/redis-client
  * https://github.com/redis-rb/redis-client
* https://rubygems.org/gems/redis-cluster-client
  * https://github.com/redis-rb/redis-cluster-client
* https://rubygems.org/gems/redis-clustering
  * https://github.com/redis/redis-rb/tree/master/cluster