### PR TITLE
Add redis-rope to the community modules list

### DIFF
--- a/modules/community/github.com/ekzhang/redis-rope.json
+++ b/modules/community/github.com/ekzhang/redis-rope.json
@@ -1,0 +1,8 @@
+{
+    "name": "redis-rope",
+    "license": "MIT",
+    "description": "A native data type for manipulating large strings up to exponentially faster, based on splay trees.",
+    "github": [
+        "ekzhang"
+    ]
+}


### PR DESCRIPTION
Adding my new [redis-rope](https://github.com/ekzhang/redis-rope) module to the list.