### PR TITLE
Latency trouble shooting

### DIFF
--- a/docs/reference/optimization/latency.md
+++ b/docs/reference/optimization/latency.md
@@ -162,6 +162,29 @@ as the main event loop.
 In most situations, these kind of system level optimizations are not needed.
 Only do them if you require them, and if you are familiar with them.
 
+It's possible to trace the real-time TCP round time trip (RTT) on Linux with the `tcprtt` utility.
+For example, here's how to use it on the server on a connection from the IP 192.168.122.100:
+
+    /usr/share/bcc/tools/tcprtt -i 1 --lport 6379 -A 192.168.122.100
+
+     usecs               : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 0        |                                        |
+        32 -> 63         : 31       |                                        |
+        64 -> 127        : 5150     |*******************                     |
+       128 -> 255        : 10327    |****************************************|
+       256 -> 511        : 1014     |***                                     |
+       512 -> 1023       : 10       |                                        |
+      1024 -> 2047       : 7        |                                        |
+      2048 -> 4095       : 14       |                                        |
+      4096 -> 8191       : 10       |                                        |
+
+The histogram makes it clear that some requests exhibit latency much higher than others.
+This suggests that the problem lies with the quality of your network service.
+
 Single threaded nature of Redis
 -------------------------------
 

--- a/docs/reference/optimization/latency.md
+++ b/docs/reference/optimization/latency.md
@@ -266,9 +266,12 @@ persist on disk. Huge pages are the cause of the following issue:
 2. In a busy instance, a few event loops runs will cause commands to target a few thousand of pages, causing the copy on write of almost the whole process memory.
 3. This will result in big latency and big memory usage.
 
-Make sure to **disable transparent huge pages** using the following command:
+Make sure to **disable transparent huge pages for entire system** using the following command:
 
     echo never > /sys/kernel/mm/transparent_hugepage/enabled
+
+Or **disable transparent huge pages for Redis alone** with a configuration directive in redis.conf (since Redis 6.2):
+    disable-thp yes
 
 Latency induced by swapping (operating system paging)
 -----------------------------------------------------


### PR DESCRIPTION
Add document for latency trouble shooting:
* Add 'disable-thp' into latency.md, reference [redis change](https://github.com/redis/redis/commit/a9c06021498444b8d785066a2fae7d49693721dc).
* Document 'Latency induced by reading smaps/smaps_rollup', reference [atop change](https://github.com/Atoptool/atop/commit/604b563a223130d9bcce3d3358537a6c5ce05e7a).
* Introduce [tcprtt](https://github.com/iovisor/bcc/blob/master/tools/tcprtt.py) to trace TCP latency,