### PR TITLE
updated install-redis-on-windows

### DIFF
--- a/docs/getting-started/installation/install-redis-on-windows.md
+++ b/docs/getting-started/installation/install-redis-on-windows.md
@@ -15,7 +15,7 @@ Microsoft provides [detailed instructions for installing WSL](https://docs.micro
 
 ## Install Redis
 
-Once you're running Ubuntu on Windows, you can follow the steps detailed at [Install on Ubuntu/Debian](install-redis-on-linux#install-on-ubuntu-debian) to install recent stable versions of Redis from the official `packages.redis.io` APT repository.
+Once you're running Ubuntu on Windows, you can follow the steps below to install recent stable versions of Redis from the official `packages.redis.io` APT repository.
 Add the repository to the <code>apt</code> index, update it, and then install:
 
 {{< highlight bash  >}}


### PR DESCRIPTION
updated install-redis-on-windows remove the link to follow install on linux. Since the link is dead and results in a 404 error