### PR TITLE
Add note about LASTSAVE without previous BGSAVE

### DIFF
--- a/commands/lastsave.md
+++ b/commands/lastsave.md
@@ -1,7 +1,7 @@
 Return the UNIX TIME of the last DB save executed with success.
 A client may check if a `BGSAVE` command succeeded reading the `LASTSAVE` value,
 then issuing a `BGSAVE` command and checking at regular intervals every N
-seconds if `LASTSAVE` changed.
+seconds if `LASTSAVE` changed. Redis considers the database saved successfully at startup.
 
 @return
 


### PR DESCRIPTION
A small note about an edge case that can lead the described procedure to hang indefinitely if BGSAVE returned the same second that redis started.