### PR TITLE
fix a markdown link syntax issue

### DIFF
--- a/docs/data-types/sets.md
+++ b/docs/data-types/sets.md
@@ -75,7 +75,7 @@ Sets membership checks on large datasets (or on streaming data) can use a lot of
 If you're concerned about memory usage and don't need perfect precision, consider a [Bloom filter or Cuckoo filter](/docs/stack/bloom) as an alternative to a set.
 
 Redis sets are frequently used as a kind of index.
-If you need to index and query your data, consider [RediSearch](/docs/stack/search)](/docs/stack/search) and [RedisJSON](/docs/stack/json).
+If you need to index and query your data, consider [RediSearch](/docs/stack/search) and [RedisJSON](/docs/stack/json).
 
 ## Learn more
 


### PR DESCRIPTION
Ran into this bit of raw markdown while reading the docs this morning:

<img width="769" alt="image" src="https://user-images.githubusercontent.com/46990/187679568-acbe15b4-c513-47b7-80f1-c6d1baa58b51.png">
