### PR TITLE
Fix inconsistent tyPING -> typing

### DIFF
--- a/docs/manual/cli.md
+++ b/docs/manual/cli.md
@@ -10,7 +10,7 @@ aliases:
 
 The Redis command line interface (`redis-cli`) is a terminal program used to send commands to and read replies from the Redis server. It has two main modes: an interactive Read Eval Print Loop (REPL) mode where the user types Redis commands and receives replies, and a command mode where `redis-cli` is executed with additional arguments and the reply is printed to the standard output.
 
-In interactive mode, `redis-cli` has basic line editing capabilities to provide a familiar tyPING experience.
+In interactive mode, `redis-cli` has basic line editing capabilities to provide a familiar typing experience.
 
 To launch the program in special modes, you can use several options, including:
 


### PR DESCRIPTION
This fixes a small typo (I believe after a `s/ping/PING/g`?) that had me wondering for a few seconds what a tyPING was, until I realised the typo. :) 