### PR TITLE
Remove duplicated explanation about backing up AOF persistence

### DIFF
--- a/docs/manual/persistence.md
+++ b/docs/manual/persistence.md
@@ -354,29 +354,6 @@ Prior to version 7.0.0 backing up the AOF file can be done simply by copying the
 but Redis will still be able to load it (see the previous sections about [truncated AOF files](#what-should-i-do-if-my-aof-gets-truncated)).
 
 
-1. Turn off automatic rewrites with<br/>
-   `CONFIG SET` `auto-aof-rewrite-percentage 0`<br/>
-   Make sure you don't manually start a rewrite (using `BGREWRITEAOF`) during this time.
-2. Check there's no current rewrite in progress using<br/>
-   `INFO` `persistence`<br/>
-   and verifying `aof_rewrite_in_progress` is 0. If it's 1, then you'll need to wait for the rewrite to complete.
-3. Now you can safely copy the files in the `appenddirname` directory.
-4. Re-enable rewrites when done:<br/>
-   `CONFIG SET` `auto-aof-rewrite-percentage <prev-value>`
-
-**Note:** If you want to minimize the time AOF rewrites are disabled you may create hard links to the files in `appenddirname` (in step 3 above) and then re-enable rewrites (step 4) after the hard links are created.
-Now you can copy/tar the hardlinks and delete them when done. This works because Redis guarantees that it
-only appends to files in this directory, or completely replaces them if necessary, so the content should be
-consistent at any given point in time.
-
-
-**Note:** If you want to handle the case of the server being restarted during the backup and make sure no rewrite will automatically start after the restart you can change step 1 above to also persist the updated configuration via `CONFIG REWRITE`.
-Just make sure to re-enable automatic rewrites when done (step 4) and persist it with another `CONFIG REWRITE`.
-
-Prior to version 7.0.0 backing up the AOF file can be done simply by copying the aof file (like backing up the RDB snapshot). The file may lack the final part
-but Redis will still be able to load it (see the previous sections about [truncated AOF files](#what-should-i-do-if-my-aof-gets-truncated)).
-
-
 ## Disaster recovery
 
 Disaster recovery in the context of Redis is basically the same story as


### PR DESCRIPTION
There is duplicated explanation about backing up AOF persistence.
https://github.com/redis/redis-doc/blob/master/docs/manual/persistence.md?plain=1#L334-L377

This CR is for removing redundant explanation.