### PR TITLE
Fix radius in GEOSEARCH example

### DIFF
--- a/docs/data-types/geospatial.md
+++ b/docs/data-types/geospatial.md
@@ -23,7 +23,7 @@ Add several locations to a geospatial index:
 (integer) 1
 ```
 
-Find all locations within a 1 kilometer radius of a given location, and return the distance to each location:
+Find all locations within a 5 kilometer radius of a given location, and return the distance to each location:
 ```
 > GEOSEARCH locations:ca FROMLONLAT -122.2612767 37.7936847 BYRADIUS 5 km WITHDIST
 1) 1) "station:1"


### PR DESCRIPTION
The example shows how to get all locations within a radius of 5 km, but the text says within 1 kilometer.

This PR will update the text to be in line with the example.