### PR TITLE
Add redis-too to the list of modules under resources

### DIFF
--- a/modules/community/github.com/hjr265/redis-too.json
+++ b/modules/community/github.com/hjr265/redis-too.json
@@ -1,0 +1,8 @@
+{
+    "name": "redis-too",
+    "license": "BSD",
+    "description": "Redis module that implements a Jaccardian similarity and memory-based collaborative filtering recommendation engine",
+    "github": [
+        "hjr265"
+    ]
+}


### PR DESCRIPTION
The Redis Too module implements a Jaccardian similarity and memory-based collaborative filtering recommendation engine.

https://github.com/hjr265/redis-too

With the module loaded, you can do something like this in Redis:

```
# Add likes
redis> TOO.LIKE movies "The Shawshank Redemption" Sonic
redis> TOO.LIKE movies "The Godfather" Sonic
redis> TOO.LIKE movies "The Dark Knight" Sonic
redis> TOO.LIKE movies "Pulp Fiction" Sonic

redis> TOO.LIKE movies "The Godfather" Mario
redis> TOO.LIKE movies "The Dark Knight" Mario
redis> TOO.LIKE movies "The Shawshank Redemption" Mario
redis> TOO.LIKE movies "The Prestige" Mario
redis> TOO.LIKE movies "The Matrix" Mario

redis> TOO.LIKE movies "The Godfather" Peach
redis> TOO.LIKE movies "Inception" Peach
redis> TOO.LIKE movies "Fight Club" Peach
redis> TOO.LIKE movies "WALL·E" Peach
redis> TOO.LIKE movies "Princess Mononoke" Peach

redis> TOO.LIKE movies "The Prestige" Luigi
redis> TOO.LIKE movies "The Dark Knight" Luigi

# Refresh recommendations
redis> TOO.REFRESH movies Sonic
redis> TOO.REFRESH movies Mario
redis> TOO.REFRESH movies Peach
redis> TOO.REFRESH movies Luigi

# Get recommendations
redis> TOO.SUGGEST movies Luigi
1) "The Shawshank Redemption"
2) "The Matrix"
3) "Pulp Fiction"
4) "The Godfather"
```