### PR TITLE
Add Redsync: Implementation of Redlock in Go

### DIFF
--- a/libraries/go/github.com/go-redsync/redsync.json
+++ b/libraries/go/github.com/go-redsync/redsync.json
@@ -1,0 +1,8 @@
+{
+    "name": "Redsync",
+    "description": "Distributed mutual exclusion lock using Redis for Go; Redsync implements the Redlock algorithm.",
+    "homepage": "https://github.com/go-redsync/redsync",
+    "github": [
+        "hjr265"
+    ]
+}


### PR DESCRIPTION
Redsync implements the Redlock algorithm in Go. The [distlock article on redis.io](https://redis.io/topics/distlock/) mentions this package as the reference Go implementation. This Go package is actively maintained and is being used in some other noteworthy open source projects.

https://github.com/go-redsync/redsync