### PR TITLE
Add description of WITHSCORE argument to ZRANK and ZREVRANK.

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -16303,13 +16303,7 @@
             "@sortedset",
             "@fast"
         ],
-        "arity": -3,
-        "history": [
-            [
-                "7.2.0",
-                "Added the optional `WITHSCORE` argument."
-            ]
-        ],
+        "arity": 3,
         "key_specs": [
             {
                 "begin_search": {
@@ -16339,12 +16333,6 @@
             {
                 "name": "member",
                 "type": "string"
-            },
-            {
-                "name": "withscore",
-                "token": "WITHSCORE",
-                "type": "pure-token",
-                "optional": true
             }
         ],
         "command_flags": [
@@ -16781,13 +16769,7 @@
             "@sortedset",
             "@fast"
         ],
-        "arity": -3,
-        "history": [
-            [
-                "7.2.0",
-                "Added the optional `WITHSCORE` argument."
-            ]
-        ],
+        "arity": 3,
         "key_specs": [
             {
                 "begin_search": {
@@ -16817,12 +16799,6 @@
             {
                 "name": "member",
                 "type": "string"
-            },
-            {
-                "name": "withscore",
-                "token": "WITHSCORE",
-                "type": "pure-token",
-                "optional": true
             }
         ],
         "command_flags": [

--- a/commands.json
+++ b/commands.json
@@ -16303,7 +16303,13 @@
             "@sortedset",
             "@fast"
         ],
-        "arity": 3,
+        "arity": -3,
+        "history": [
+            [
+                "7.2.0",
+                "Added the optional `WITHSCORE` argument."
+            ]
+        ],
         "key_specs": [
             {
                 "begin_search": {
@@ -16333,6 +16339,12 @@
             {
                 "name": "member",
                 "type": "string"
+            },
+            {
+                "name": "withscore",
+                "token": "WITHSCORE",
+                "type": "pure-token",
+                "optional": true
             }
         ],
         "command_flags": [
@@ -16769,7 +16781,13 @@
             "@sortedset",
             "@fast"
         ],
-        "arity": 3,
+        "arity": -3,
+        "history": [
+            [
+                "7.2.0",
+                "Added the optional `WITHSCORE` argument."
+            ]
+        ],
         "key_specs": [
             {
                 "begin_search": {
@@ -16799,6 +16817,12 @@
             {
                 "name": "member",
                 "type": "string"
+            },
+            {
+                "name": "withscore",
+                "token": "WITHSCORE",
+                "type": "pure-token",
+                "optional": true
             }
         ],
         "command_flags": [

--- a/commands/zrank.md
+++ b/commands/zrank.md
@@ -3,14 +3,21 @@ ordered from low to high.
 The rank (or index) is 0-based, which means that the member with the lowest
 score has rank `0`.
 
+The optional `WITHSCORE` argument supplements the command's reply with the score of the element returned.
+
 Use `ZREVRANK` to get the rank of an element with the scores ordered from high
 to low.
 
 @return
 
-* If `member` exists in the sorted set, @integer-reply: the rank of `member`.
-* If `member` does not exist in the sorted set or `key` does not exist,
-  @bulk-string-reply: `nil`.
+* If `member` exists in the sorted set:
+  * using `WITHSCORE`, @array-reply: an array containing the rank and score of `member`.
+  * without using `WITHSCORE`, @integer-reply: the rank of `member`.
+* If `member` does not exist in the sorted set or `key` does not exist:
+  * using `WITHSCORE`, @array-reply: `nil`.
+  * without using `WITHSCORE`, @bulk-string-reply: `nil`.
+  
+Note that in RESP3 null and nullarray are the same, but in RESP2 they are not.
 
 @examples
 
@@ -20,4 +27,6 @@ ZADD myzset 2 "two"
 ZADD myzset 3 "three"
 ZRANK myzset "three"
 ZRANK myzset "four"
+ZRANK myzset "three" WITHSCORE
+ZRANK myzset "four" WITHSCORE
 ```

--- a/commands/zrevrank.md
+++ b/commands/zrevrank.md
@@ -3,14 +3,21 @@ ordered from high to low.
 The rank (or index) is 0-based, which means that the member with the highest
 score has rank `0`.
 
+The optional `WITHSCORE` argument supplements the command's reply with the score of the element returned.
+
 Use `ZRANK` to get the rank of an element with the scores ordered from low to
 high.
 
 @return
 
-* If `member` exists in the sorted set, @integer-reply: the rank of `member`.
-* If `member` does not exist in the sorted set or `key` does not exist,
-  @bulk-string-reply: `nil`.
+* If `member` exists in the sorted set:
+  * using `WITHSCORE`, @array-reply: an array containing the rank and score of `member`.
+  * without using `WITHSCORE`, @integer-reply: the rank of `member`.
+* If `member` does not exist in the sorted set or `key` does not exist:
+  * using `WITHSCORE`, @array-reply: `nil`.
+  * without using `WITHSCORE`, @bulk-string-reply: `nil`.
+  
+Note that in RESP3 null and nullarray are the same, but in RESP2 they are not.
 
 @examples
 
@@ -20,4 +27,6 @@ ZADD myzset 2 "two"
 ZADD myzset 3 "three"
 ZREVRANK myzset "one"
 ZREVRANK myzset "four"
+ZREVRANK myzset "three" WITHSCORE
+ZREVRANK myzset "four" WITHSCORE
 ```

--- a/wordlist
+++ b/wordlist
@@ -724,6 +724,7 @@ notifyKeyspaceEvent
 num-items
 numactl
 numkeys
+nullarray
 observability
 odown
 ok


### PR DESCRIPTION
For PR redis/redis#11235, which adds the `WITHSCORE` option to command `ZRANK` and `ZREVRANK`.
Add description of option `WITHSCORE` argument to `zrank.md` and `zrevrank.md`.
Modify `commands.json`.