### PR TITLE
docs: correct minimum possible id

### DIFF
--- a/commands/xrange.md
+++ b/commands/xrange.md
@@ -41,9 +41,8 @@ will just return every entry in the stream:
 ... other entries here ...
 ```
 
-The `-` ID is effectively just exactly as specifying `0-1`, while
-`+` is equivalent to `18446744073709551615-18446744073709551615`, however
-they are nicer to type.
+The `-` and `+` special IDs mean, respectively, the minimal and maximal range IDs,
+however they are nicer to type.
 
 ## Incomplete IDs
 

--- a/commands/xrange.md
+++ b/commands/xrange.md
@@ -41,7 +41,7 @@ will just return every entry in the stream:
 ... other entries here ...
 ```
 
-The `-` ID is effectively just exactly as specifying `0-0`, while
+The `-` ID is effectively just exactly as specifying `0-1`, while
 `+` is equivalent to `18446744073709551615-18446744073709551615`, however
 they are nicer to type.
 


### PR DESCRIPTION
Everywhere across the docs, as well in the Redis University course RU202, it's stated that the minimal possible id is `0-1`, but not `0-0`