### PR TITLE
Update encryption.md

### DIFF
--- a/docs/management/security/encryption.md
+++ b/docs/management/security/encryption.md
@@ -20,7 +20,7 @@ that needs to be enabled at compile time.
 To build with TLS support you'll need OpenSSL development libraries (e.g.
 libssl-dev on Debian/Ubuntu).
 
-Run `make BUILD_TLS=yes`.
+Run `make BUILD_TLS=yes`
 
 ### Tests
 

--- a/docs/management/security/encryption.md
+++ b/docs/management/security/encryption.md
@@ -18,9 +18,13 @@ that needs to be enabled at compile time.
 ### Building
 
 To build with TLS support you'll need OpenSSL development libraries (e.g.
-libssl-dev on Debian/Ubuntu).
+`libssl-dev` on Debian/Ubuntu).
 
-Run `make BUILD_TLS=yes`
+Build Redis with the following command:
+
+```sh
+make BUILD_TLS=yes
+```
 
 ### Tests
 


### PR DESCRIPTION
When installing Redis TLS,
Run `make BUILD_TLS=yes` <--- Need to install it with the corresponding command to install it correctly. However,
Run `make BUILD_TLS=yes`. <---  Due to the '.'dot, a TLS testing error occurred due to a misunderstanding, so we request a correction.