### PR TITLE
fix: setbit should return 0 on an empty instance

### DIFF
--- a/docs/data-types/tutorial.md
+++ b/docs/data-types/tutorial.md
@@ -880,7 +880,7 @@ a user wants to receive a newsletter) of 4 billion of users using just 512 MB of
 Bits are set and retrieved using the `SETBIT` and `GETBIT` commands:
 
     > setbit key 10 1
-    (integer) 1
+    (integer) 0
     > getbit key 10
     (integer) 1
     > getbit key 11

--- a/docs/manual/pubsub.md
+++ b/docs/manual/pubsub.md
@@ -77,12 +77,18 @@ environment (test, staging, production...).
 
 ```
 SUBSCRIBE first second
-1) "subscribe"
-2) "first"
-3) (integer) 1
-1) "subscribe"
-2) "second"
-3) (integer) 2
+*3
+$9
+subscribe
+$5
+first
+:1
+*3
+$9
+subscribe
+$6
+second
+:2
 ```
 
 At this point, from another client we issue a `PUBLISH` operation
@@ -95,9 +101,13 @@ against the channel named `second`:
 This is what the first client receives:
 
 ```
-1) "message"
-2) "second"
-3) "Hello"
+*3
+$7
+message
+$6
+second
+$5
+Hello
 ```
 
 Now the client unsubscribes itself from all the channels using the
@@ -105,12 +115,18 @@ Now the client unsubscribes itself from all the channels using the
 
 ```
 UNSUBSCRIBE
-1) "unsubscribe"
-2) "second"
-3) (integer) 1
-1) "unsubscribe"
-2) "first"
-3) (integer) 0
+*3
+$11
+unsubscribe
+$6
+second
+:1
+*3
+$11
+unsubscribe
+$5
+first
+:0
 ```
 
 ## Pattern-matching subscriptions

--- a/docs/manual/pubsub.md
+++ b/docs/manual/pubsub.md
@@ -77,18 +77,12 @@ environment (test, staging, production...).
 
 ```
 SUBSCRIBE first second
-*3
-$9
-subscribe
-$5
-first
-:1
-*3
-$9
-subscribe
-$6
-second
-:2
+1) "subscribe"
+2) "first"
+3) (integer) 1
+1) "subscribe"
+2) "second"
+3) (integer) 2
 ```
 
 At this point, from another client we issue a `PUBLISH` operation
@@ -101,13 +95,9 @@ against the channel named `second`:
 This is what the first client receives:
 
 ```
-*3
-$7
-message
-$6
-second
-$5
-Hello
+1) "message"
+2) "second"
+3) "Hello"
 ```
 
 Now the client unsubscribes itself from all the channels using the
@@ -115,18 +105,12 @@ Now the client unsubscribes itself from all the channels using the
 
 ```
 UNSUBSCRIBE
-*3
-$11
-unsubscribe
-$6
-second
-:1
-*3
-$11
-unsubscribe
-$5
-first
-:0
+1) "unsubscribe"
+2) "second"
+3) (integer) 1
+1) "unsubscribe"
+2) "first"
+3) (integer) 0
 ```
 
 ## Pattern-matching subscriptions


### PR DESCRIPTION
setbit return the original bit value stored at offset, so `setbit key 10 1` should return 0.