### PR TITLE
Added SwiftyRedis as a swift client

### DIFF
--- a/clients/swift/github.com/michaelvanstraten/Swifty-Redis.json
+++ b/clients/swift/github.com/michaelvanstraten/Swifty-Redis.json
@@ -1,5 +1,5 @@
 {
     "name": "SwiftyRedis",
     "description": "SwiftyRedis is a high level async redis library for Swift. ",
-    "homepage": "https://michaelvanstraten.github.io/swifty-redis/documentation/swiftyredis/",
+    "homepage": "https://michaelvanstraten.github.io/swifty-redis/documentation/swiftyredis/"
 }

--- a/clients/swift/github.com/michaelvanstraten/Swifty-Redis.json
+++ b/clients/swift/github.com/michaelvanstraten/Swifty-Redis.json
@@ -1,0 +1,5 @@
+{
+    "name": "SwiftyRedis",
+    "description": "SwiftyRedis is a high level async redis library for Swift. ",
+    "homepage": "https://michaelvanstraten.github.io/swifty-redis/documentation/swiftyredis/",
+}


### PR DESCRIPTION
Dear Redis Developer Team,

A few months back I was developing a swift app for which I needed a Redis client. 
I took a look at the https://redis.io/resources/clients/#swift recommended clients,
but I could not find one that integrates well with the current async await standards of swift. 

I decided to develop my own client using the new asynchronous swift concurrency framework.
Would it be possible to list my package under the list of available clients?

Some of the features of this package include:
- 240 command implemented and documented
- adheres to Redis 7.0 standard
- implements modern swift concurrency
- offers vast documentation using apple docC framework (tutorial section not completed) 
- easily extendable
- generic type system for return type
maybe some could take a look at it.

Thank you in advance for considering my request.

Best regards Michael van Straten