### PR TITLE
Update MEMORY USAGE doc to be more specific about SAMPLES

### DIFF
--- a/commands/memory-usage.md
+++ b/commands/memory-usage.md
@@ -5,8 +5,8 @@ The reported usage is the total of memory allocations for data and
 administrative overheads that a key its value require.
 
 For nested data types, the optional `SAMPLES` option can be provided, where
-`count` is the number of sampled nested values. By default, this option is set
-to `5`. To sample the all of the nested values, use `SAMPLES 0`. 
+`count` is the number of sampled nested values. The samples are averaged to estimate the total size.
+By default, this option is set to `5`. To sample the all of the nested values, use `SAMPLES 0`.
 
 @examples
 


### PR DESCRIPTION
Adds an extra statement to make clearer that N samples are averaged and then the result is multiplied by nested key's cardinality. The docstring for the function has this extra specificity, so this change just carries it over into the docs: https://github1s.com/redis/redis/blob/HEAD/src/object.c#L992. 