### PR TITLE
Add jodersky/redicl client

### DIFF
--- a/clients/scala/github.com/jodersky/redicl.json
+++ b/clients/scala/github.com/jodersky/redicl.json
@@ -1,0 +1,5 @@
+{
+    "name": "redicl",
+    "description": "A lean and mean redis client implementation that uses only the Scala standard library. Available for the JVM and native.",
+    "homepage": "https://github.com/jodersky/redicl"
+}


### PR DESCRIPTION
This is [a relatively new client for Scala that I created](https://github.com/jodersky/redicl). It uses only the standard Scala library, is minimal but still very expressive (somewhat inspired by the Python client's API).