### PR TITLE
removal of $ from $ brew -version command

### DIFF
--- a/docs/getting-started/installation/install-redis-on-mac-os.md
+++ b/docs/getting-started/installation/install-redis-on-mac-os.md
@@ -12,7 +12,7 @@ This guide shows you how to install Redis on macOS using Homebrew. Homebrew is t
 First, make sure you have Homebrew installed. From the terminal, run:
 
 {{< highlight bash  >}}
-$ brew --version
+brew --version
 {{< / highlight >}}
 
 If this command fails, you'll need to [follow the Homebrew installation instructions](https://brew.sh/).


### PR DESCRIPTION
On the Install Redis on macOs page the command to check brew version contains $ in its line. Since rest of the commands given in the document start directly from brew and not $ brew as $ is already present in the terminal it will be easier to just keep brew --version so that the user can directly copy that command in their terminal, else they'll have to remove $ from the command line manually. This seems much easier from a user's perspective to copy directly and paste the command without failure.