### PR TITLE
fix broken hash in link to "read-only scripts" heading

### DIFF
--- a/commands/eval_ro.md
+++ b/commands/eval_ro.md
@@ -1,6 +1,6 @@
 This is a read-only variant of the `EVAL` command that cannot execute commands that modify data.
 
-For more information about when to use this command vs `EVAL`, please refer to [Read-only scripts](/docs/manual/programmability/#read-only_scripts).
+For more information about when to use this command vs `EVAL`, please refer to [Read-only scripts](/docs/manual/programmability/#read-only-scripts).
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).
 


### PR DESCRIPTION
I noticed the link to [this heading](https://redis.io/docs/manual/programmability/#read-only-scripts) was broken, so I fixed it.