### PR TITLE
correcting return value when destination key already exists for copy …

### DIFF
--- a/commands/copy.md
+++ b/commands/copy.md
@@ -5,7 +5,7 @@ By default, the `destination` key is created in the logical database used by the
 connection. The `DB` option allows specifying an alternative logical database
 index for the destination key.
 
-The command returns an error when the `destination` key already exists. The
+The command returns zero when the `destination` key already exists. The
 `REPLACE` option removes the `destination` key before copying the value to it.
 
 @return


### PR DESCRIPTION
As per the current design of copy commands it returns zero when destination already exist.
this is also documented in the `Returns` section below this text.

![image](https://github.com/redis/redis-doc/assets/51993843/8078d68c-05e8-45ad-8b50-2cd48c0d5753)



