### PR TITLE
Add redis-llm to community module list

### DIFF
--- a/modules/community/github.com/sewenew/redis-llm.json
+++ b/modules/community/github.com/sewenew/redis-llm.json
@@ -1,0 +1,8 @@
+{
+    "name": "redis-llm",
+    "license": "Apache-2.0",
+    "description": "Redis module integrating LLM (Large Language Model) with Redis",
+    "github": [
+        "sewenew"
+    ]
+}


### PR DESCRIPTION
Add [redis-llm](https://github.com/sewenew/redis-llm) module to community module list. This module helps LLM to access private data, and remember long chat history.