### PR TITLE
DOC-2511: reorder the clients by language list

### DIFF
--- a/clients/csharp/github.com/redis/NRedisStack.json
+++ b/clients/csharp/github.com/redis/NRedisStack.json
@@ -1,5 +1,5 @@
 {
     "name": "NRedisStack",
     "description": "This client is developed by Redis to bring RedisStack support to CSharp.",
-    "recommended": true
+    "official": true
 }

--- a/clients/go/github.com/redis/go-redis.json
+++ b/clients/go/github.com/redis/go-redis.json
@@ -1,5 +1,5 @@
 {
     "name": "go-redis",
     "description": "Redis client for Golang supporting Redis Sentinel and Redis Cluster out of the box.",
-    "recommended": true
+    "official": true
 }

--- a/clients/java/github.com/redis/jedis.json
+++ b/clients/java/github.com/redis/jedis.json
@@ -1,7 +1,7 @@
 {
     "name": "Jedis",
     "description": "A blazingly small and sane Redis Java client",
-    "recommended": true,
+    "official": true,
     "twitter": [
         "xetorthio",
         "g_korland"

--- a/clients/nodejs/github.com/redis/node-redis.json
+++ b/clients/nodejs/github.com/redis/node-redis.json
@@ -1,5 +1,5 @@
 {
     "name": "node-redis",
     "description": "Recommended client for node.",
-    "recommended": true
+    "official": true
 }

--- a/clients/python/github.com/redis/redis-py.json
+++ b/clients/python/github.com/redis/redis-py.json
@@ -1,5 +1,5 @@
 {
     "name": "redis-py",
     "description": "Mature and supported. The way to go for Python.",
-    "recommended": true
+    "official": true
 }

--- a/resources/clients/index.md
+++ b/resources/clients/index.md
@@ -2,7 +2,7 @@
 title: "Clients"
 linkTitle: "Clients"
 weight: 10
-description: Implementations of the Redis protocol in different programming languages. To get started see [Client quickstarts](/docs/clients/).
+description: Implementations of the Redis protocol in different programming languages. To get started with an official client, click on one of the quickstart guide links below.
 layout: bazzar
 bazzar: clients
 aliases:


### PR DESCRIPTION
"Official" clients are now marked as `official: true` instead of `recommended: true`.

This PR is dependent on [this PR](https://github.com/redis-stack/redis-stack-website/pull/113).