### PR TITLE
Update strings.md , wrong command description

### DIFF
--- a/docs/data-types/strings.md
+++ b/docs/data-types/strings.md
@@ -78,7 +78,7 @@ you can perform with them. For instance, one is atomic increment:
     (integer) 11
 {{< /clients-example >}}
 
-The `INCRBY` command parses the string value as an integer,
+The `INCR` command parses the string value as an integer,
 increments it by one, and finally sets the obtained value as the new value.
 There are other similar commands like `INCRBY`,
 `DECR` and `DECRBY`. Internally it's


### PR DESCRIPTION
The string value is parsed into integer and incremented by one by the `INCR` command not the `INCRBY`.  `INCRBY` command increments the value with a given value not by 1 automatically. It increments the value by one if only it is explicitly told : `incrby total_crashes 1`