### PR TITLE
Remove unnecessary code in streams consumer implementation

### DIFF
--- a/docs/data-types/streams.md
+++ b/docs/data-types/streams.md
@@ -458,8 +458,6 @@ while true
 
         # Acknowledge the message as processed
         r.xack(:my_stream_key,GroupName,id)
-
-        $lastid = id
     }
 end
 ```


### PR DESCRIPTION
When the loop is still going through backlog, whether $lastid is '0-0' or the id of the last processed message, both have same outcome in this context.  Also, once the consumer is caught up with backlog, the id used becomes `'>'`. So it looks like saving the id of last processed message is unnecessary.