### PR TITLE
Improve RDB to AOF conversion docs

### DIFF
--- a/docs/management/persistence.md
+++ b/docs/management/persistence.md
@@ -274,20 +274,15 @@ Switch to AOF on live database:
 
 * Enable AOF: `redis-cli config set appendonly yes`
 * Optionally disable RDB: `redis-cli config set save ""`
-* Wait for AOF rewrite to finish persisting the data. You can do that by
-  watching `INFO persistence`, waiting for `aof_rewrite_in_progress` and
-  `aof_rewrite_scheduled` to be `0`, and validate that
-  `aof_last_bgrewrite_status` is `ok`.
-* **IMPORTANT:** Update your `redis.conf` (potentially through `CONFIG
-  REWRITE`) and ensure that it matches the config above. (If you forget this
-  step, when you restart the server, the configuration changes will be lost and
-  the server will start again with the old configuration, resulting in a loss
-  of your data.)
+* Make sure writes are appended to the append only file correctly.
+* **IMPORTANT:** Update your `redis.conf` (potentially through `CONFIG REWRITE`) and ensure that it matches the config above.
+  (If you forget this step, when you restart the server, the configuration changes will be lost and the server will start again with the old configuration, resulting in a loss of your data.)
 
 Next time you restart the server:
 
+* Wait for AOF rewrite to finish persisting the data.
+  You can do that by watching `INFO persistence`, waiting for `aof_rewrite_in_progress` and `aof_rewrite_scheduled` to be `0`, and validate that `aof_last_bgrewrite_status` is `ok`.
 * Make sure your database contains the same number of keys it contained previously.
-* Make sure writes are appended to the append only file correctly.
 
 **Redis 2.0**
 

--- a/docs/management/persistence.md
+++ b/docs/management/persistence.md
@@ -275,14 +275,14 @@ Switch to AOF on live database:
 * Enable AOF: `redis-cli config set appendonly yes`
 * Optionally disable RDB: `redis-cli config set save ""`
 * Make sure writes are appended to the append only file correctly.
-* **IMPORTANT:** Update your `redis.conf` (potentially through `CONFIG REWRITE`) and ensure that it matches the config above.
-  (If you forget this step, when you restart the server, the configuration changes will be lost and the server will start again with the old configuration, resulting in a loss of your data.)
+* **IMPORTANT:** Update your `redis.conf` (potentially through `CONFIG REWRITE`) and ensure that it matches the configuration above.
+  If you forget this step, when you restart the server, the configuration changes will be lost and the server will start again with the old configuration, resulting in a loss of your data.
 
 Next time you restart the server:
 
-* Wait for AOF rewrite to finish persisting the data.
-  You can do that by watching `INFO persistence`, waiting for `aof_rewrite_in_progress` and `aof_rewrite_scheduled` to be `0`, and validate that `aof_last_bgrewrite_status` is `ok`.
-* Make sure your database contains the same number of keys it contained previously.
+* Before restarting the server, wait for AOF rewrite to finish persisting the data.
+  You can do that by watching `INFO persistence`, waiting for `aof_rewrite_in_progress` and `aof_rewrite_scheduled` to be `0`, and validating that `aof_last_bgrewrite_status` is `ok`.
+* After restarting the server, check that your database contains the same number of keys it contained previously.
 
 **Redis 2.0**
 

--- a/wordlist
+++ b/wordlist
@@ -183,6 +183,7 @@ codenamed
 Collina's
 commandstats
 commnad
+CONFIG
 Config
 config
 config-file


### PR DESCRIPTION
As discussed in https://github.com/redis/redis/issues/12484, here is a suggestion for improved AOF conversion documentation.

The first commit just adds a simple warning. In the second commit, I removed the section for Redis <2.2, which is out of support for a long time now. (If I'm not mistaken, 2.2 was released in 2011.)

I can also squash the two commits at request.