### PR TITLE
Moving HMSET used by examples to HSET

### DIFF
--- a/commands/hrandfield.md
+++ b/commands/hrandfield.md
@@ -18,7 +18,7 @@ If the `WITHVALUES` modifier is used, the reply is a list fields and their value
 @examples
 
 ```cli
-HMSET coin heads obverse tails reverse edge null
+HSET coin heads obverse tails reverse edge null
 HRANDFIELD coin
 HRANDFIELD coin
 HRANDFIELD coin -5 WITHVALUES

--- a/commands/hstrlen.md
+++ b/commands/hstrlen.md
@@ -7,7 +7,7 @@ Returns the string length of the value associated with `field` in the hash store
 @examples
 
 ```cli
-HMSET myhash f1 HelloWorld f2 99 f3 -256
+HSET myhash f1 HelloWorld f2 99 f3 -256
 HSTRLEN myhash f1
 HSTRLEN myhash f2
 HSTRLEN myhash f3


### PR DESCRIPTION
[HMSET](https://redis.io/commands/hmset/) is deprecated as of Redis 4.0.0, and [HSET ](https://redis.io/commands/hset/) is the prefered method for this interaction. This PR updates the examples where we were refering to the deprecated command.