### PR TITLE
Add RESP3 reply schemas to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,49 @@ into account:
     These keywords will get expanded and auto-linked to relevant parts of the
     documentation.
 
-There should be at least two predefined sections: description and return value.
-The return value section is marked using the @return keyword:
+Each command will have a description and both RESP2 and RESP3 return values.
+Regarding the return values, these are contained in the files:
+
+* `resp2_replies.json`
+* `resp3_replies.json`
+
+Each file is a dictionary with a matching set of keys. Each key is an array of strings that,
+when processed, produce Markdown content. Here's an example:
 
 ```
-Returns all keys matching the given pattern.
-
-@return
-
-@multi-bulk-reply: all the keys that matched the pattern.
+{
+  ...
+  "ACL CAT": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL categories or commands in a given category.",
+    "* [Simple error reply](/docs/reference/protocol-spec#simple-errors): the command returns an error if an invalid category name is given."
+  ],
+  ...
+}
 ```
+
+**Important**: when adding or editing return values, be sure to edit both files. Use the following
+links for the reply type. Note: do not use `@reply-type` specifiers; use only the Markdown link.
+
+```md
+@simple-string-reply: [Simple string reply](https://redis.io/docs/reference/protocol-spec#simple-strings)
+@simple-error-reply: [Simple error reply](https://redis.io/docs/reference/protocol-spec#simple-errors)
+@integer-reply: [Integer reply](https://redis.io/docs/reference/protocol-spec#integers)
+@bulk-string-reply: [Bulk string reply](https://redis.io/docs/reference/protocol-spec#bulk-strings)
+@array-reply: [Array reply](https://redis.io/docs/reference/protocol-spec#arrays)
+@nil-reply: [Nil reply](https://redis.io/docs/reference/protocol-spec#bulk-strings)
+@null-reply: [Null reply](https://redis.io/docs/reference/protocol-spec#nulls)
+@boolean-reply: [Boolean reply](https://redis.io/docs/reference/protocol-spec#booleans)
+@double-reply: [Double reply](https://redis.io/docs/reference/protocol-spec#doubles)
+@big-number-reply: [Big number reply](https://redis.io/docs/reference/protocol-spec#big-numbers)
+@bulk-error-reply: [Bulk error reply](https://redis.io/docs/reference/protocol-spec#bulk-errors)
+@verbatim-string-reply: [Verbatim string reply](https://redis.io/docs/reference/protocol-spec#verbatim-strings)
+@map-reply: [Map reply](https://redis.io/docs/reference/protocol-spec#maps)
+@set-reply: [Set reply](https://redis.io/docs/reference/protocol-spec#sets)
+@push-reply: [Push reply](https://redis.io/docs/reference/protocol-spec#pushes)
+```
+
+**Note:** RESP3 return schemas are not currently included in the `resp2/resp3_replies.json` files for Redis Stack modules.
 
 ## Styling guidelines
 

--- a/commands/acl-cat.md
+++ b/commands/acl-cat.md
@@ -76,7 +76,3 @@ Then we may want to know what commands are part of a given category:
 30) "psync"
 31) "sort"
 ```
-
-@return
-
-@array-reply: a list of ACL categories or a list of commands inside a given category. The command may return an error if an invalid category name is given as argument.

--- a/commands/acl-deluser.md
+++ b/commands/acl-deluser.md
@@ -4,10 +4,6 @@ removed from the system, this is the default user that every new connection
 is authenticated with. The list of users may include usernames that do not
 exist, in such case no operation is performed for the non existing users.
 
-@return
-
-@integer-reply: The number of users that were deleted. This number will not always match the number of arguments since certain users may not exist.
-
 @examples
 
 ```

--- a/commands/acl-dryrun.md
+++ b/commands/acl-dryrun.md
@@ -1,11 +1,6 @@
 Simulate the execution of a given command by a given user.
 This command can be used to test the permissions of a given user without having to enable the user or cause the side effects of running the command.
 
-@return
-
-@simple-string-reply: `OK` on success.
-@bulk-string-reply: An error describing why the user can't execute the command.
-
 @examples
 
 ```

--- a/commands/acl-genpass.md
+++ b/commands/acl-genpass.md
@@ -25,10 +25,6 @@ rounded to the next multiple of 4. So for instance asking for just 1
 bit password will result in 4 bits to be emitted, in the form of a single
 hex character.
 
-@return
-
-@bulk-string-reply: by default 64 bytes string representing 256 bits of pseudorandom data. Otherwise if an argument if needed, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4.
-
 @examples
 
 ```

--- a/commands/acl-getuser.md
+++ b/commands/acl-getuser.md
@@ -9,10 +9,6 @@ Note: This description of command rules reflects the user's effective permission
 
 Selectors are listed in the order they were applied to the user, and include information about commands, key patterns, and channel patterns.
 
-@array-reply: a list of ACL rule definitions for the user.
-
-If `user` does not exist a @nil-reply is returned.
-
 @examples
 
 Here's an example configuration for a user

--- a/commands/acl-help.md
+++ b/commands/acl-help.md
@@ -1,5 +1,2 @@
 The `ACL HELP` command returns a helpful text describing the different subcommands.
 
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/acl-list.md
+++ b/commands/acl-list.md
@@ -4,10 +4,6 @@ same used in the redis.conf file or the external ACL file, so you can
 cut and paste what is returned by the ACL LIST command directly inside a
 configuration file if you wish (but make sure to check `ACL SAVE`).
 
-@return
-
-An array of strings.
-
 @examples
 
 ```

--- a/commands/acl-load.md
+++ b/commands/acl-load.md
@@ -6,12 +6,6 @@ sure to have an *all or nothing* behavior, that is:
 * If every line in the file is valid, all the ACLs are loaded.
 * If one or more line in the file is not valid, nothing is loaded, and the old ACL rules defined in the server memory continue to be used.
 
-@return
-
-@simple-string-reply: `OK` on success.
-
-The command may fail with an error for several reasons: if the file is not readable, if there is an error inside the file, and in such case the error will be reported to the user in the error. Finally the command will fail if the server is not configured to use an external ACL file.
-
 @examples
 
 ```

--- a/commands/acl-log.md
+++ b/commands/acl-log.md
@@ -8,16 +8,6 @@ The optional argument specifies how many entries to show. By default
 up to ten failures are returned. The special `RESET` argument clears the log.
 Entries are displayed starting from the most recent.
 
-@return
-
-When called to show security events:
-
-@array-reply: a list of ACL security events.
-
-When called with `RESET`:
-
-@simple-string-reply: `OK` if the security log was cleared.
-
 @examples
 
 ```

--- a/commands/acl-save.md
+++ b/commands/acl-save.md
@@ -1,12 +1,6 @@
 When Redis is configured to use an ACL file (with the `aclfile` configuration
 option), this command will save the currently defined ACLs from the server memory to the ACL file.
 
-@return
-
-@simple-string-reply: `OK` on success.
-
-The command may fail with an error for several reasons: if the file cannot be written or if the server is not configured to use an external ACL file.
-
 @examples
 
 ```

--- a/commands/acl-setuser.md
+++ b/commands/acl-setuser.md
@@ -84,12 +84,6 @@ This is a list of all the supported Redis ACL rules:
 * `clearselectors`: (Available in Redis 7.0 and later) Deletes all of the selectors attached to the user.
 * `reset`: Removes any capability from the user. They are set to off, without passwords, unable to execute any command, unable to access any key.
 
-@return
-
-@simple-string-reply: `OK` on success.
-
-If the rules contain errors, the error is returned.
-
 @examples
 
 ```

--- a/commands/acl-users.md
+++ b/commands/acl-users.md
@@ -1,10 +1,6 @@
 The command shows a list of all the usernames of the currently configured
 users in the Redis ACL system.
 
-@return
-
-An array of strings.
-
 @examples
 
 ```

--- a/commands/acl-whoami.md
+++ b/commands/acl-whoami.md
@@ -2,10 +2,6 @@ Return the username the current connection is authenticated with.
 New connections are authenticated with the "default" user. They
 can change user using `AUTH`.
 
-@return
-
-@bulk-string-reply: the username of the current connection.
-
 @examples
 
 ```

--- a/commands/append.md
+++ b/commands/append.md
@@ -3,10 +3,6 @@ end of the string.
 If `key` does not exist it is created and set as an empty string, so `APPEND`
 will be similar to `SET` in this special case.
 
-@return
-
-@integer-reply: the length of the string after the append operation.
-
 @examples
 
 ```cli

--- a/commands/asking.md
+++ b/commands/asking.md
@@ -4,7 +4,3 @@ This is normally done automatically by cluster clients.
 If an `-ASK` redirect is received during a transaction, only one ASKING command needs to be sent to the target node before sending the complete transaction to the target node.
 
 See [ASK redirection in the Redis Cluster Specification](/topics/cluster-spec#ask-redirection) for details.
-
-@return
-
-@simple-string-reply: `OK`.

--- a/commands/auth.md
+++ b/commands/auth.md
@@ -30,7 +30,3 @@ Because of the high performance nature of Redis, it is possible to try
 a lot of passwords in parallel in very short time, so make sure to generate a
 strong and very long password so that this attack is infeasible.
 A good way to generate strong passwords is via the `ACL GENPASS` command.
-
-@return
-
-@simple-string-reply or an error if the password, or username/password pair, is invalid.

--- a/commands/bgrewriteaof.md
+++ b/commands/bgrewriteaof.md
@@ -23,8 +23,3 @@ Please refer to the [persistence documentation][tp] for detailed information.
 
 [tp]: /topics/persistence
 
-@return
-
-@simple-string-reply: A simple string reply indicating that the rewriting started or is about to start ASAP, when the call is executed with success.
-
-The command may reply with an error in certain cases, as documented above.

--- a/commands/bgsave.md
+++ b/commands/bgsave.md
@@ -19,6 +19,3 @@ Please refer to the [persistence documentation][tp] for detailed information.
 
 [tp]: /topics/persistence
 
-@return
-
-@simple-string-reply: `Background saving started` if `BGSAVE` started correctly or `Background saving scheduled` when used with the `SCHEDULE` subcommand. 

--- a/commands/bitcount.md
+++ b/commands/bitcount.md
@@ -15,12 +15,6 @@ We can use an additional argument `BIT` to specify a bit index.
 So 0 is the first bit, 1 is the second bit, and so forth.
 For negative values, -1 is the last bit, -2 is the penultimate, and so forth.
 
-@return
-
-@integer-reply
-
-The number of bits set to 1.
-
 @examples
 
 ```cli

--- a/commands/bitfield.md
+++ b/commands/bitfield.md
@@ -78,12 +78,6 @@ By default, **WRAP** is used if not otherwise specified.
     1) (integer) 0
     2) (integer) 3
 
-## Return value
-
-The command returns an array with each entry being the corresponding result of
-the sub command given at the same position. `OVERFLOW` subcommands don't count
-as generating a reply.
-
 The following is an example of `OVERFLOW FAIL` returning NULL.
 
     > BITFIELD mykey OVERFLOW FAIL incrby u2 102 1

--- a/commands/bitfield_ro.md
+++ b/commands/bitfield_ro.md
@@ -13,7 +13,3 @@ See original `BITFIELD` for more details.
 ```
 BITFIELD_RO hello GET i8 16
 ```
-
-@return
-
-@array-reply: An array with each entry being the corresponding result of the subcommand given at the same position.

--- a/commands/bitop.md
+++ b/commands/bitop.md
@@ -24,13 +24,6 @@ zero-padded up to the length of the longest string.
 The same holds true for non-existent keys, that are considered as a stream of
 zero bytes up to the length of the longest string.
 
-@return
-
-@integer-reply
-
-The size of the string stored in the destination key, that is equal to the
-size of the longest input string.
-
 @examples
 
 ```cli

--- a/commands/bitpos.md
+++ b/commands/bitpos.md
@@ -22,20 +22,6 @@ bit, -2 is the penultimate, and so forth.
 
 Non-existent keys are treated as empty strings.
 
-@return
-
-@integer-reply
-
-The command returns the position of the first bit set to 1 or 0 according to the request.
-
-If we look for set bits (the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.
-
-If we look for clear bits (the bit argument is 0) and the string only contains bit set to 1, the function returns the first bit not part of the string on the right. So if the string is three bytes set to the value `0xff` the command `BITPOS key 0` will return 24, since up to bit 23 all the bits are 1.
-
-Basically, the function considers the right of the string as padded with zeros if you look for clear bits and specify no range or the _start_ argument **only**.
-
-However, this behavior changes if you are looking for clear bits and specify a range with both __start__ and __end__. If no clear bit is found in the specified range, the function returns -1 as the user specified a clear range and there are no 0 bits in that range.
-
 @examples
 
 ```cli

--- a/commands/blmove.md
+++ b/commands/blmove.md
@@ -10,11 +10,6 @@ This command comes in place of the now deprecated `BRPOPLPUSH`. Doing
 
 See `LMOVE` for more information.
 
-@return
-
-@bulk-string-reply: the element being popped from `source` and pushed to `destination`.
-If `timeout` is reached, a @nil-reply is returned.
-
 ## Pattern: Reliable queue
 
 Please see the pattern description in the `LMOVE` documentation.

--- a/commands/blmpop.md
+++ b/commands/blmpop.md
@@ -6,10 +6,3 @@ When all lists are empty, Redis will block the connection until another client p
 A `timeout` of zero can be used to block indefinitely.
 
 See `LMPOP` for more information.
-
-@return
-
-@array-reply: specifically:
-
-* A `nil` when no element could be popped, and timeout is reached.
-* A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of elements.

--- a/commands/blpop.md
+++ b/commands/blpop.md
@@ -82,15 +82,6 @@ thing that happens when the timeout is reached.
 If you like science fiction, think of time flowing at infinite speed inside a
 `MULTI` / `EXEC` block...
 
-@return
-
-@array-reply: specifically:
-
-* A `nil` multi-bulk when no element could be popped and the timeout expired.
-* A two-element multi-bulk with the first element being the name of the key
-  where an element was popped and the second element being the value of the
-  popped element.
-
 @examples
 
 ```

--- a/commands/brpop.md
+++ b/commands/brpop.md
@@ -10,15 +10,6 @@ the tail of a list instead of popping from the head.
 
 [cb]: /commands/blpop
 
-@return
-
-@array-reply: specifically:
-
-* A `nil` multi-bulk when no element could be popped and the timeout expired.
-* A two-element multi-bulk with the first element being the name of the key
-  where an element was popped and the second element being the value of the
-  popped element.
-
 @examples
 
 ```

--- a/commands/brpoplpush.md
+++ b/commands/brpoplpush.md
@@ -7,11 +7,6 @@ A `timeout` of zero can be used to block indefinitely.
 
 See `RPOPLPUSH` for more information.
 
-@return
-
-@bulk-string-reply: the element being popped from `source` and pushed to `destination`.
-If `timeout` is reached, a @nil-reply is returned.
-
 ## Pattern: Reliable queue
 
 Please see the pattern description in the `RPOPLPUSH` documentation.

--- a/commands/bzmpop.md
+++ b/commands/bzmpop.md
@@ -6,11 +6,3 @@ When all sorted sets are empty, Redis will block the connection until another cl
 A `timeout` of zero can be used to block indefinitely.
 
 See `ZMPOP` for more information.
-
-@return
-
-@array-reply: specifically:
-
-* A `nil` when no element could be popped.
-* A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score.
-

--- a/commands/bzpopmax.md
+++ b/commands/bzpopmax.md
@@ -14,15 +14,6 @@ with the highest scores instead of popping the ones with the lowest scores.
 
 [cb]: /commands/bzpopmin
 
-@return
-
-@array-reply: specifically:
-
-* A `nil` multi-bulk when no element could be popped and the timeout expired.
-* A three-element multi-bulk with the first element being the name of the key
-  where a member was popped, the second element is the popped member itself,
-  and the third element is the score of the popped element.
-
 @examples
 
 ```

--- a/commands/bzpopmin.md
+++ b/commands/bzpopmin.md
@@ -14,15 +14,6 @@ popped from.
 
 [cl]: /commands/blpop
 
-@return
-
-@array-reply: specifically:
-
-* A `nil` multi-bulk when no element could be popped and the timeout expired.
-* A three-element multi-bulk with the first element being the name of the key
-  where a member was popped, the second element is the popped member itself,
-  and the third element is the score of the popped element.
-
 @examples
 
 ```

--- a/commands/client-caching.md
+++ b/commands/client-caching.md
@@ -16,7 +16,3 @@ tracked using `CLIENT CACHING no`.
 Basically the command sets a state in the connection, that is valid only
 for the next command execution, that will modify the behavior of client
 tracking.
-
-@return
-
-@simple-string-reply: `OK` or an error if the argument is not yes or no.

--- a/commands/client-getname.md
+++ b/commands/client-getname.md
@@ -1,5 +1,1 @@
 The `CLIENT GETNAME` returns the name of the current connection as set by `CLIENT SETNAME`. Since every new connection starts without an associated name, if no name was assigned a null bulk reply is returned.
-
-@return
-
-@bulk-string-reply: The connection name, or a null bulk reply if no name is set.

--- a/commands/client-getredir.md
+++ b/commands/client-getredir.md
@@ -5,7 +5,3 @@ order to avoid forcing client libraries implementations to remember the
 ID notifications are redirected to, this command exists in order to improve
 introspection and allow clients to check later if redirection is active
 and towards which client ID.
-
-@return
-
-@integer-reply: the ID of the client we are redirecting the notifications to. The command returns `-1` if client tracking is not enabled, or `0` if client tracking is enabled but we are not redirecting the notifications to any client.

--- a/commands/client-help.md
+++ b/commands/client-help.md
@@ -1,5 +1,1 @@
 The `CLIENT HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/client-id.md
+++ b/commands/client-id.md
@@ -12,9 +12,3 @@ introduced also in Redis 5 together with `CLIENT ID`. Check the `CLIENT UNBLOCK`
 ```cli
 CLIENT ID
 ```
-
-@return
-
-@integer-reply
-
-The id of the client.

--- a/commands/client-info.md
+++ b/commands/client-info.md
@@ -7,7 +7,3 @@ The reply format is identical to that of `CLIENT LIST`, and the content consists
 ```cli
 CLIENT INFO
 ```
-
-@return
-
-@bulk-string-reply: a unique string, as described at the `CLIENT LIST` page, for the current client.

--- a/commands/client-kill.md
+++ b/commands/client-kill.md
@@ -41,13 +41,3 @@ the client point of view, the connection can never be closed
 in the middle of the execution of a command. However, the client
 will notice the connection has been closed only when the
 next command is sent (and results in network error).
-
-@return
-
-When called with the three arguments format:
-
-@simple-string-reply: `OK` if the connection exists and has been closed
-
-When called with the filter / value format:
-
-@integer-reply: the number of clients killed.

--- a/commands/client-list.md
+++ b/commands/client-list.md
@@ -5,14 +5,6 @@ You can use one of the optional subcommands to filter the list. The `TYPE type` 
 
 The `ID` filter only returns entries for clients with IDs matching the `client-id` arguments.
 
-@return
-
-@bulk-string-reply: a unique string, formatted as follows:
-
-* One client connection per line (separated by LF)
-* Each line is composed of a succession of `property=value` fields separated
-  by a space character.
-
 Here is the meaning of the fields:
 
 * `id`: a unique 64-bit client ID

--- a/commands/client-no-evict.md
+++ b/commands/client-no-evict.md
@@ -5,7 +5,3 @@ When turned on and client eviction is configured, the current connection will be
 When turned off, the current client will be re-included in the pool of potential clients to be evicted (and evicted if needed).
 
 See [client eviction](/topics/clients#client-eviction) for more details.
-
-@return
-
-@simple-string-reply: `OK`.

--- a/commands/client-no-touch.md
+++ b/commands/client-no-touch.md
@@ -3,7 +3,3 @@ The `CLIENT NO-TOUCH` command controls whether commands sent by the client will 
 When turned on, the current client will not change LFU/LRU stats, unless it sends the `TOUCH` command.
 
 When turned off, the client touches LFU/LRU stats just as a normal client.
-
-@return
-
-@simple-string-reply: `OK`.

--- a/commands/client-pause.md
+++ b/commands/client-pause.md
@@ -35,10 +35,6 @@ Since Redis 3.2.10 / 4.0.0, this command also prevents keys to be evicted or
 expired during the time clients are paused. This way the dataset is guaranteed
 to be static not just from the point of view of clients not being able to write, but also from the point of view of internal operations.
 
-@return
-
-@simple-string-reply: The command returns OK or an error if the timeout is invalid.
-
 ## Behavior change history
 
 *   `>= 3.2.0`: Client pause prevents client pause and key eviction as well.

--- a/commands/client-reply.md
+++ b/commands/client-reply.md
@@ -5,9 +5,3 @@ The `CLIENT REPLY` command controls whether the server will reply the client's c
 * `ON`. This is the default mode in which the server returns a reply to every command.
 * `OFF`. In this mode the server will not reply to client commands.
 * `SKIP`. This mode skips the reply of command immediately after it.
-
-@return
-
-When called with either `OFF` or `SKIP` subcommands, no reply is made. When called with `ON`:
-
-@simple-string-reply: `OK`.

--- a/commands/client-setinfo.md
+++ b/commands/client-setinfo.md
@@ -10,7 +10,3 @@ Currently the supported attributes are:
 There is no limit to the length of these attributes. However it is not possible to use spaces, newlines, or other non-printable characters that would violate the format of the `CLIENT LIST` reply.
 
 Note that these attributes are **not** cleared by the RESET command.
-
-@return
-
-@simple-string-reply: `OK` if the attribute name was successfully set.

--- a/commands/client-setname.md
+++ b/commands/client-setname.md
@@ -13,7 +13,3 @@ The connection name can be inspected using `CLIENT GETNAME`.
 Every new connection starts without an assigned name.
 
 Tip: setting names to connections is a good way to debug connection leaks due to bugs in the application using Redis.
-
-@return
-
-@simple-string-reply: `OK` if the connection name was successfully set.

--- a/commands/client-tracking.md
+++ b/commands/client-tracking.md
@@ -27,7 +27,3 @@ command when enabling tracking:
 * `OPTIN`: when broadcasting is NOT active, normally don't track keys in read only commands, unless they are called immediately after a `CLIENT CACHING yes` command.
 * `OPTOUT`: when broadcasting is NOT active, normally track keys in read only commands, unless they are called immediately after a `CLIENT CACHING no` command.
 * `NOLOOP`: don't send notifications about keys modified by this connection itself.
-
-@return
-
-@simple-string-reply: `OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise an error is returned.

--- a/commands/client-trackinginfo.md
+++ b/commands/client-trackinginfo.md
@@ -1,8 +1,6 @@
 The command returns information about the current client connection's use of the [server assisted client side caching](/topics/client-side-caching) feature.
 
-@return
-
-@array-reply: a list of tracking information sections and their respective values, specifically:
+Here's the list of tracking information sections and their respective values:
 
 * **flags**: A list of tracking flags used by the connection. The flags and their meanings are as follows:
   * `off`: The connection isn't using server assisted client side caching.

--- a/commands/client-unblock.md
+++ b/commands/client-unblock.md
@@ -49,10 +49,3 @@ NULL
 > BRPOP key1 key2 key3 key4 0
 (client is blocked again)
 ```
-
-@return
-
-@integer-reply, specifically:
-
-* `1` if the client was unblocked successfully.
-* `0` if the client wasn't unblocked.

--- a/commands/client-unpause.md
+++ b/commands/client-unpause.md
@@ -1,5 +1,1 @@
 `CLIENT UNPAUSE` is used to resume command processing for all clients that were paused by `CLIENT PAUSE`.
-
-@return
-
-@simple-string-reply: The command returns `OK`

--- a/commands/cluster-addslots.md
+++ b/commands/cluster-addslots.md
@@ -45,7 +45,3 @@ This means that this command should be used with care only by applications
 orchestrating Redis Cluster, like `redis-cli`, and the command if used
 out of the right context can leave the cluster in a wrong state or cause
 data loss.
-
-@return
-
-@simple-string-reply: `OK` if the command was successful. Otherwise an error is returned.

--- a/commands/cluster-addslotsrange.md
+++ b/commands/cluster-addslotsrange.md
@@ -21,7 +21,3 @@ This command only works in cluster mode and is useful in the following Redis Clu
 
 1. To create a new cluster, `CLUSTER ADDSLOTSRANGE` is used to initially set up master nodes splitting the available hash slots among them.
 2. In order to fix a broken cluster where certain slots are unassigned.
-
-@return
-
-@simple-string-reply: `OK` if the command was successful. Otherwise an error is returned.

--- a/commands/cluster-bumpepoch.md
+++ b/commands/cluster-bumpepoch.md
@@ -3,7 +3,3 @@ Advances the cluster config epoch.
 The `CLUSTER BUMPEPOCH` command triggers an increment to the cluster's config epoch from the connected node. The epoch will be incremented if the node's config epoch is zero, or if it is less than the cluster's greatest epoch.
 
 **Note:** config epoch management is performed internally by the cluster, and relies on obtaining a consensus of nodes. The `CLUSTER BUMPEPOCH` attempts to increment the config epoch **WITHOUT** getting the consensus, so using it may violate the "last failover wins" rule. Use it with caution.
-
-@return
-
-@simple-string-reply: `BUMPED` if the epoch was incremented, or `STILL` if the node already has the greatest config epoch in the cluster.

--- a/commands/cluster-count-failure-reports.md
+++ b/commands/cluster-count-failure-reports.md
@@ -16,7 +16,3 @@ This command returns the number of failure reports for the current node which ar
 
 This command is mainly useful for debugging, when the failure detector of
 Redis Cluster is not operating as we believe it should.
-
-@return
-
-@integer-reply: the number of active failure reports for the node.

--- a/commands/cluster-countkeysinslot.md
+++ b/commands/cluster-countkeysinslot.md
@@ -7,7 +7,3 @@ zero being returned.
 > CLUSTER COUNTKEYSINSLOT 7000
 (integer) 50341
 ```
-
-@return
-
-@integer-reply: The number of keys in the specified hash slot, or an error if the hash slot is invalid.

--- a/commands/cluster-delslots.md
+++ b/commands/cluster-delslots.md
@@ -41,8 +41,3 @@ This command only works in cluster mode and may be useful for
 debugging and in order to manually orchestrate a cluster configuration
 when a new cluster is created. It is currently not used by `redis-cli`,
 and mainly exists for API completeness.
-
-@return
-
-@simple-string-reply: `OK` if the command was successful. Otherwise
-an error is returned.

--- a/commands/cluster-delslotsrange.md
+++ b/commands/cluster-delslotsrange.md
@@ -25,8 +25,3 @@ This command only works in cluster mode and may be useful for
 debugging and in order to manually orchestrate a cluster configuration
 when a new cluster is created. It is currently not used by `redis-cli`,
 and mainly exists for API completeness.
-
-@return
-
-@simple-string-reply: `OK` if the command was successful. Otherwise
-an error is returned.

--- a/commands/cluster-failover.md
+++ b/commands/cluster-failover.md
@@ -61,7 +61,3 @@ Because of this the **TAKEOVER** option should be used with care.
   To check that the masters are aware of a new replica, you can send `CLUSTER NODES` or `CLUSTER REPLICAS` to each of the master nodes and check that it appears as a replica, before sending `CLUSTER FAILOVER` to the replica.
 * To check that the failover has actually happened you can use `ROLE`, `INFO REPLICATION` (which indicates "role:master" after successful failover), or `CLUSTER NODES` to verify that the state of the cluster has changed sometime after the command was sent.
 * To check if the failover has failed, check the replica's log for "Manual failover timed out", which is logged if the replica has given up after a few seconds.
-
-@return
-
-@simple-string-reply: `OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if we are talking with a node which is already a master.

--- a/commands/cluster-flushslots.md
+++ b/commands/cluster-flushslots.md
@@ -1,7 +1,3 @@
 Deletes all slots from a node.
 
 The `CLUSTER FLUSHSLOTS` deletes all information about slots from the connected node. It can only be called when the database is empty.
-
-@return
-
-@simple-string-reply: `OK`

--- a/commands/cluster-forget.md
+++ b/commands/cluster-forget.md
@@ -51,7 +51,3 @@ The command does not succeed and returns an error in the following cases:
 1. The specified node ID is not found in the nodes table.
 2. The node receiving the command is a replica, and the specified node ID identifies its current master.
 3. The node ID identifies the same node we are sending the command to.
-
-@return
-
-@simple-string-reply: `OK` if the command was executed successfully, otherwise an error is returned.

--- a/commands/cluster-getkeysinslot.md
+++ b/commands/cluster-getkeysinslot.md
@@ -14,7 +14,3 @@ of the `CLUSTER SETSLOT` command documentation.
 2) "key_89793"
 3) "key_92937"
 ```
-
-@return
-
-@array-reply: From 0 to *count* key names in a Redis array reply.

--- a/commands/cluster-help.md
+++ b/commands/cluster-help.md
@@ -1,5 +1,1 @@
 The `CLUSTER HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/cluster-info.md
+++ b/commands/cluster-info.md
@@ -46,7 +46,3 @@ Here are the explanation of these fields:
 * `cluster_stats_messages_publishshard_sent` and `cluster_stats_messages_publishshard_received`: Pub/Sub Publish shard propagation, see [Sharded Pubsub](/topics/pubsub#sharded-pubsub).
 
 More information about the Current Epoch and Config Epoch variables are available in the [Redis Cluster specification document](/topics/cluster-spec#cluster-current-epoch).
-
-@return
-
-@bulk-string-reply: A map between named fields and values in the form of `<field>:<value>` lines separated by newlines composed by the two bytes `CRLF`.

--- a/commands/cluster-keyslot.md
+++ b/commands/cluster-keyslot.md
@@ -18,7 +18,3 @@ Example use cases for this command:
 ```
 
 Note that the command implements the full hashing algorithm, including support for **hash tags**, that is the special property of Redis Cluster key hashing algorithm, of hashing just what is between `{` and `}` if such a pattern is found inside the key name, in order to force multiple keys to be handled by the same node.
-
-@return
-
-@integer-reply: The hash slot number.

--- a/commands/cluster-links.md
+++ b/commands/cluster-links.md
@@ -42,7 +42,3 @@ Each map is composed of the following attributes of the corresponding cluster li
 4. `events`: Events currently registered for the link. `r` means readable event, `w` means writable event.
 5. `send-buffer-allocated`: Allocated size of the link's send buffer, which is used to buffer outgoing messages toward the peer.
 6. `send-buffer-used`: Size of the portion of the link's send buffer that is currently holding data(messages).
-
-@return
-
-@array-reply: An array of maps where each map contains various attributes and their values of a cluster link.

--- a/commands/cluster-meet.md
+++ b/commands/cluster-meet.md
@@ -36,7 +36,3 @@ the node to force the receiver to accept it as a trusted node, it sends a
 `MEET` packet instead of a `PING` packet. The two packets have exactly the
 same format, but the former forces the receiver to acknowledge the node as
 trusted.
-
-@return
-
-@simple-string-reply: `OK` if the command was successful. If the address or port specified are invalid an error is returned.

--- a/commands/cluster-myid.md
+++ b/commands/cluster-myid.md
@@ -1,7 +1,3 @@
 Returns the node's id.
 
 The `CLUSTER MYID` command returns the unique, auto-generated identifier that is associated with the connected cluster node.
-
-@return
-
-@bulk-string-reply: The node id.

--- a/commands/cluster-myshardid.md
+++ b/commands/cluster-myshardid.md
@@ -1,7 +1,3 @@
 Returns the node's shard id.
 
 The `CLUSTER MYSHARDID` command returns the unique, auto-generated identifier that is associated with the shard to which the connected cluster node belongs.
-
-@return
-
-@bulk-string-reply: The node's shard id.

--- a/commands/cluster-nodes.md
+++ b/commands/cluster-nodes.md
@@ -104,8 +104,4 @@ Note that:
 1. Migration and importing slots are only added to the node flagged as `myself`. This information is local to a node, for its own slots.
 2. Importing and migrating slots are provided as **additional info**. If the node has a given hash slot assigned, it will be also a plain number in the list of hash slots, so clients that don't have a clue about hash slots migrations can just skip this special fields.
 
-@return
-
-@bulk-string-reply: The serialized cluster configuration.
-
 **A note about the word slave used in this man page and command name**: Starting with Redis 5, if not for backward compatibility, the Redis project no longer uses the word slave. Unfortunately in this command the word slave is part of the protocol, so we'll be able to remove such occurrences only when this API will be naturally deprecated.

--- a/commands/cluster-replicas.md
+++ b/commands/cluster-replicas.md
@@ -9,7 +9,3 @@ and we ask `CLUSTER REPLICAS` to a node that has not yet received the
 configuration update, it may show stale information. However eventually
 (in a matter of seconds if there are no network partitions) all the nodes
 will agree about the set of nodes associated with a given master.
-
-@return
-
-The command returns data in the same format as `CLUSTER NODES`.

--- a/commands/cluster-replicate.md
+++ b/commands/cluster-replicate.md
@@ -20,7 +20,3 @@ only if the following additional conditions are met:
 2. The node is empty, no keys are stored at all in the key space.
 
 If the command succeeds the new replica will immediately try to contact its master in order to replicate from it.
-
-@return
-
-@simple-string-reply: `OK` if the command was executed successfully, otherwise an error is returned.

--- a/commands/cluster-reset.md
+++ b/commands/cluster-reset.md
@@ -19,7 +19,3 @@ is also extensively used by the Redis Cluster testing framework in order to
 reset the state of the cluster every time a new test unit is executed.
 
 If no reset type is specified, the default is **soft**.
-
-@return
-
-@simple-string-reply: `OK` if the command was successful. Otherwise an error is returned.

--- a/commands/cluster-saveconfig.md
+++ b/commands/cluster-saveconfig.md
@@ -9,7 +9,3 @@ configuration via the `CLUSTER` command in order to ensure the new configuration
 is persisted on disk, however all the commands should normally be able to
 auto schedule to persist the configuration on disk when it is important
 to do so for the correctness of the system in the event of a restart.
-
-@return
-
-@simple-string-reply: `OK` or an error if the operation fails.

--- a/commands/cluster-set-config-epoch.md
+++ b/commands/cluster-set-config-epoch.md
@@ -19,7 +19,3 @@ configuration epoch.
 So, using `CLUSTER SET-CONFIG-EPOCH`, when a new cluster is created, we can
 assign a different progressive configuration epoch to each node before
 joining the cluster together.
-
-@return
-
-@simple-string-reply: `OK` if the command was executed successfully, otherwise an error is returned.

--- a/commands/cluster-setslot.md
+++ b/commands/cluster-setslot.md
@@ -60,10 +60,6 @@ command:
 
 It is important to note that step 3 is the only time when a Redis Cluster node will create a new config epoch without agreement from other nodes. This only happens when a manual configuration is operated. However it is impossible that this creates a non-transient setup where two nodes have the same config epoch, since Redis Cluster uses a config epoch collision resolution algorithm.
 
-@return
-
-@simple-string-reply: All the subcommands return `OK` if the command was successful. Otherwise an error is returned.
-
 ## Redis Cluster live resharding explained
 
 The `CLUSTER SETSLOT` command is an important piece used by Redis Cluster in order to migrate all the keys contained in one hash slot from one node to another. This is how the migration is orchestrated, with the help of other commands as well. We'll call the node that has the current ownership of the hash slot the `source` node, and the node where we want to migrate the `destination` node.

--- a/commands/cluster-shards.md
+++ b/commands/cluster-shards.md
@@ -50,10 +50,6 @@ This can happen in a cluster that consists of only one node or the node has not 
 The value `?` is displayed if the node is incorrectly configured to use announced hostnames but no hostname is configured using `cluster-announce-hostname`.
 Clients may treat the empty string in the same way as NULL, that is the same endpoint it used to send the current command to, while `"?"` should be treated as an unknown node, not necessarily the same node as the one serving the current command.
 
-@return
-
-@array-reply: nested list of a map of hash ranges and shard nodes.
-
 @examples
 
 ```

--- a/commands/cluster-slaves.md
+++ b/commands/cluster-slaves.md
@@ -11,7 +11,3 @@ and we ask `CLUSTER SLAVES` to a node that has not yet received the
 configuration update, it may show stale information. However eventually
 (in a matter of seconds if there are no network partitions) all the nodes
 will agree about the set of nodes associated with a given master.
-
-@return
-
-The command returns data in the same format as `CLUSTER NODES`.

--- a/commands/cluster-slots.md
+++ b/commands/cluster-slots.md
@@ -41,12 +41,6 @@ All networking information after the third nested reply are replicas of the mast
 
 If a cluster instance has non-contiguous slots (e.g. 1-400,900,1800-6000) then master and replica networking information results will be duplicated for each top-level slot range reply.
 
-@return
-
-@array-reply: nested list of slot ranges with networking information.
-
-@examples
-
 ```
 > CLUSTER SLOTS
 1) 1) (integer) 0

--- a/commands/command-count.md
+++ b/commands/command-count.md
@@ -1,9 +1,5 @@
 Returns @integer-reply of number of total commands in this Redis server.
 
-@return
-
-@integer-reply: number of commands returned by `COMMAND`
-
 @examples
 
 ```cli

--- a/commands/command-docs.md
+++ b/commands/command-docs.md
@@ -44,10 +44,6 @@ The following keys may be included in the mapped reply:
 
 [td]: /topics/command-arguments
 
-@return
-
-@array-reply: a map as a flattened array as described above.
-
 @examples
 
 ```cli

--- a/commands/command-getkeys.md
+++ b/commands/command-getkeys.md
@@ -7,11 +7,6 @@ from a full Redis command.
 but in some cases it's not possible to find keys of certain commands and then the entire command must be parsed to discover some / all key names.
 You can use `COMMAND GETKEYS` or `COMMAND GETKEYSANDFLAGS` to discover key names directly from how Redis parses the commands.
 
-
-@return
-
-@array-reply: list of keys from your command.
-
 @examples
 
 ```cli

--- a/commands/command-getkeysandflags.md
+++ b/commands/command-getkeysandflags.md
@@ -8,11 +8,6 @@ You can use `COMMAND GETKEYS` or `COMMAND GETKEYSANDFLAGS` to discover key names
 
 Refer to [key specifications](/topics/key-specs#logical-operation-flags) for information about the meaning of the key flags.
 
-@return
-
-@array-reply: list of keys from your command.
-Each element of the array is an array containing key name in the first entry, and flags in the second.
-
 @examples
 
 ```cli

--- a/commands/command-help.md
+++ b/commands/command-help.md
@@ -1,5 +1,1 @@
 The `COMMAND HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/command-info.md
+++ b/commands/command-info.md
@@ -6,11 +6,6 @@ get returned.
 If you request details about non-existing commands, their return
 position will be nil.
 
-
-@return
-
-@array-reply: nested list of command details.
-
 @examples
 
 ```cli

--- a/commands/command-list.md
+++ b/commands/command-list.md
@@ -5,7 +5,3 @@ You can use the optional _FILTERBY_ modifier to apply one of the following filte
  - **MODULE module-name**: get the commands that belong to the module specified by _module-name_.
  - **ACLCAT category**: get the commands in the [ACL category](/docs/management/security/acl/#command-categories) specified by _category_.
  - **PATTERN pattern**: get the commands that match the given glob-like _pattern_.
-
-@return
-
-@array-reply: a list of command names.

--- a/commands/command.md
+++ b/commands/command.md
@@ -196,12 +196,6 @@ Each element in the array represents one subcommand and follows the same specifi
 [td]: /topics/key-specs
 [tr]: /topics/key-specs
 
-@return
-
-@array-reply: a nested list of command details.
-
-The order of commands in the array is random.
-
 @examples
 
 The following is `COMMAND`'s output for the `GET` command:

--- a/commands/config-get.md
+++ b/commands/config-get.md
@@ -38,8 +38,3 @@ configuration parameter used in the [redis.conf][hgcarr22rc] file:
 Note that you should look at the redis.conf file relevant to the version you're
 working with as configuration options might change between versions. The link
 above is to the latest development version.
-
-
-@return
-
-The return type of the command is a @array-reply.

--- a/commands/config-help.md
+++ b/commands/config-help.md
@@ -1,5 +1,1 @@
 The `CONFIG HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/config-resetstat.md
+++ b/commands/config-resetstat.md
@@ -8,7 +8,3 @@ The following is a non-exhaustive list of values that are reset:
 * Connections received, rejected and evicted
 * Persistence statistics
 * Active defragmentation statistics
-
-@return
-
-@simple-string-reply: always `OK`.

--- a/commands/config-rewrite.md
+++ b/commands/config-rewrite.md
@@ -13,8 +13,3 @@ CONFIG REWRITE is also able to rewrite the configuration file from scratch if th
 ## Atomic rewrite process
 
 In order to make sure the redis.conf file is always consistent, that is, on errors or crashes you always end with the old file, or the new one, the rewrite is performed with a single `write(2)` call that has enough content to be at least as big as the old file. Sometimes additional padding in the form of comments is added in order to make sure the resulting file is big enough, and later the file gets truncated to remove the padding at the end.
-
-@return
-
-@simple-string-reply: `OK` when the configuration was rewritten properly.
-Otherwise an error is returned.

--- a/commands/config-set.md
+++ b/commands/config-set.md
@@ -34,8 +34,3 @@ Redis server that started with AOF turned on since the start.
 
 You can have both the AOF enabled with RDB snapshotting if you want, the two
 options are not mutually exclusive.
-
-@return
-
-@simple-string-reply: `OK` when the configuration was set properly.
-Otherwise an error is returned.

--- a/commands/copy.md
+++ b/commands/copy.md
@@ -8,13 +8,6 @@ index for the destination key.
 The command returns zero when the `destination` key already exists. The
 `REPLACE` option removes the `destination` key before copying the value to it.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if `source` was copied.
-* `0` if `source` was not copied.
-
 @examples
 
 ```

--- a/commands/dbsize.md
+++ b/commands/dbsize.md
@@ -1,5 +1,1 @@
 Return the number of keys in the currently-selected database.
-
-@return
-
-@integer-reply

--- a/commands/decr.md
+++ b/commands/decr.md
@@ -6,10 +6,6 @@ This operation is limited to **64 bit signed integers**.
 
 See `INCR` for extra information on increment/decrement operations.
 
-@return
-
-@integer-reply: the value of `key` after the decrement
-
 @examples
 
 ```cli

--- a/commands/decrby.md
+++ b/commands/decrby.md
@@ -6,10 +6,6 @@ This operation is limited to 64 bit signed integers.
 
 See `INCR` for extra information on increment/decrement operations.
 
-@return
-
-@integer-reply: the value of `key` after the decrement
-
 @examples
 
 ```cli

--- a/commands/del.md
+++ b/commands/del.md
@@ -1,10 +1,6 @@
 Removes the specified keys.
 A key is ignored if it does not exist.
 
-@return
-
-@integer-reply: The number of keys that were removed.
-
 @examples
 
 ```cli

--- a/commands/discard.md
+++ b/commands/discard.md
@@ -4,7 +4,3 @@ connection state to normal.
 [tt]: /topics/transactions
 
 If `WATCH` was used, `DISCARD` unwatches all keys watched by the connection.
-
-@return
-
-@simple-string-reply: always `OK`.

--- a/commands/dump.md
+++ b/commands/dump.md
@@ -21,10 +21,6 @@ should be used.
 
 If `key` does not exist a nil bulk reply is returned.
 
-@return
-
-@bulk-string-reply: the serialized value.
-
 @examples
 
 ```

--- a/commands/echo.md
+++ b/commands/echo.md
@@ -1,9 +1,5 @@
 Returns `message`.
 
-@return
-
-@bulk-string-reply
-
 @examples
 
 ```cli

--- a/commands/exec.md
+++ b/commands/exec.md
@@ -7,10 +7,3 @@ When using `WATCH`, `EXEC` will execute commands only if the watched keys were
 not modified, allowing for a [check-and-set mechanism][ttc].
 
 [ttc]: /topics/transactions#cas
-
-@return
-
-@array-reply: each element being the reply to each of the commands in the
-atomic transaction.
-
-When using `WATCH`, `EXEC` can return a @nil-reply if the execution was aborted.

--- a/commands/exists.md
+++ b/commands/exists.md
@@ -2,10 +2,6 @@ Returns if `key` exists.
 
 The user should be aware that if the same existing key is mentioned in the arguments multiple times, it will be counted multiple times. So if `somekey` exists, `EXISTS somekey somekey` will return 2.
 
-@return
-
-@integer-reply, specifically the number of keys that exist from those specified as arguments.
-
 @examples
 
 ```cli

--- a/commands/expire.md
+++ b/commands/expire.md
@@ -60,13 +60,6 @@ are now fixed.
 
 `EXPIRE` would return 0 and not alter the timeout for a key with a timeout set.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the timeout was set.
-* `0` if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.
-
 @examples
 
 ```cli

--- a/commands/expireat.md
+++ b/commands/expireat.md
@@ -27,13 +27,6 @@ The `EXPIREAT` command supports a set of options:
 A non-volatile key is treated as an infinite TTL for the purpose of `GT` and `LT`.
 The `GT`, `LT` and `NX` options are mutually exclusive.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the timeout was set.
-* `0` if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.
-
 @examples
 
 ```cli

--- a/commands/expiretime.md
+++ b/commands/expiretime.md
@@ -2,13 +2,6 @@ Returns the absolute Unix timestamp (since January 1, 1970) in seconds at which 
 
 See also the `PEXPIRETIME` command which returns the same information with milliseconds resolution.
 
-@return
-
-@integer-reply: Expiration Unix timestamp in seconds, or a negative value in order to signal an error (see the description below).
-
-* The command returns `-1` if the key exists but has no associated expiration time.
-* The command returns `-2` if the key does not exist.
-
 @examples
 
 ```cli

--- a/commands/failover.md
+++ b/commands/failover.md
@@ -42,7 +42,3 @@ The command has no side effects if issued in the `waiting-for-sync` state but ca
 If a multi-master scenario is encountered, you will need to manually identify which master has the latest data and designate it as the master and have the other replicas.
 
 NOTE: `REPLICAOF` is disabled while a failover is in progress, this is to prevent unintended interactions with the failover that might cause data loss.
-
-@return
-
-@simple-string-reply: `OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed.

--- a/commands/flushall.md
+++ b/commands/flushall.md
@@ -11,10 +11,6 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 Note: an asynchronous `FLUSHALL` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
 
-@return
-
-@simple-string-reply
-
 ## Behavior change history
 
 *   `>= 6.2.0`: Default flush behavior now configurable by the **lazyfree-lazy-user-flush** configuration directive. 

--- a/commands/flushdb.md
+++ b/commands/flushdb.md
@@ -11,10 +11,6 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 Note: an asynchronous `FLUSHDB` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
 
-@return
-
-@simple-string-reply
-
 ## Behavior change history
 
 *   `>= 6.2.0`: Default flush behavior now configurable by the **lazyfree-lazy-user-flush** configuration directive. 

--- a/commands/function-delete.md
+++ b/commands/function-delete.md
@@ -5,10 +5,6 @@ If the library doesn't exist, the server returns an error.
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).
 
-@return
-
-@simple-string-reply
-
 @examples
 
 ```

--- a/commands/function-dump.md
+++ b/commands/function-dump.md
@@ -3,10 +3,6 @@ You can restore the serialized payload later with the `FUNCTION RESTORE` command
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).
 
-@return
-
-@bulk-string-reply: the serialized payload
-
 @examples
 
 The following example shows how to dump loaded libraries using `FUNCTION DUMP` and then it calls `FUNCTION FLUSH` deletes all the libraries.

--- a/commands/function-flush.md
+++ b/commands/function-flush.md
@@ -6,7 +6,3 @@ Unless called with the optional mode argument, the `lazyfree-lazy-user-flush` co
 * `!SYNC`: Synchronously flush the libraries.
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).
-
-@return
-
-@simple-string-reply

--- a/commands/function-help.md
+++ b/commands/function-help.md
@@ -1,5 +1,1 @@
 The `FUNCTION HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/function-kill.md
+++ b/commands/function-kill.md
@@ -4,7 +4,3 @@ Kill a function that is currently executing.
 The `FUNCTION KILL` command can be used only on functions that did not modify the dataset during their execution (since stopping a read-only function does not violate the scripting engine's guaranteed atomicity).
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).
-
-@return
-
-@simple-string-reply

--- a/commands/function-list.md
+++ b/commands/function-list.md
@@ -15,7 +15,3 @@ The following information is provided for each of the libraries in the response:
 * **library_code:** the library's source code (when given the `WITHCODE` modifier).
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).
-
-@return
-
-@array-reply

--- a/commands/function-load.md
+++ b/commands/function-load.md
@@ -20,10 +20,6 @@ The command will return an error in the following circumstances:
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).
 
-@return
-
-@string - the library name that was loaded
-
 @examples
 
 The following example will create a library named `mylib` with a single function, `myfunc`, that returns the first argument it gets.

--- a/commands/function-restore.md
+++ b/commands/function-restore.md
@@ -9,7 +9,3 @@ The following policies are allowed:
 * **REPLACE:** appends the restored libraries to the existing libraries, replacing any existing ones in case of name collisions. Note that this policy doesn't prevent function name collisions, only libraries.
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).
-
-@return
-
-@simple-string-reply

--- a/commands/function-stats.md
+++ b/commands/function-stats.md
@@ -15,7 +15,3 @@ The reply is map with two keys:
 You can use this command to inspect the invocation of a long-running function and decide whether kill it with the `FUNCTION KILL` command.
 
 For more information please refer to [Introduction to Redis Functions](/topics/functions-intro).
-
-@return
-
-@array-reply

--- a/commands/geoadd.md
+++ b/commands/geoadd.md
@@ -39,13 +39,6 @@ The model assumes that the Earth is a sphere since it uses the Haversine formula
 The introduced errors are not an issue when used, for example, by social networks and similar applications requiring this type of querying. 
 However, in the worst case, the error may be up to 0.5%, so you may want to consider other systems for error-critical applications.
 
-@return
-
-@integer-reply, specifically:
-
-* When used without optional arguments, the number of elements added to the sorted set (excluding score updates).
-* If the `CH` option is specified, the number of elements that were changed (added or updated).
-
 @examples
 
 ```cli

--- a/commands/geodist.md
+++ b/commands/geodist.md
@@ -13,13 +13,6 @@ The unit must be one of the following, and defaults to meters:
 
 The distance is computed assuming that the Earth is a perfect sphere, so errors up to 0.5% are possible in edge cases.
 
-@return
-
-@bulk-string-reply, specifically:
-
-The command returns the distance as a double (represented as a string)
-in the specified unit, or NULL if one or both the elements are missing.
-
 @examples
 
 ```cli

--- a/commands/geohash.md
+++ b/commands/geohash.md
@@ -18,13 +18,6 @@ have the following properties:
 2. It is possible to use them in `geohash.org` URLs such as `http://geohash.org/<geohash-string>`. This is an [example of such URL](http://geohash.org/sqdtr74hyu0).
 3. Strings with a similar prefix are nearby, but the contrary is not true, it is possible that strings with different prefixes are nearby too.
 
-@return
-
-@array-reply, specifically:
-
-The command returns an array where each element is the Geohash corresponding to
-each member name passed as argument to the command.
-
 @examples
 
 ```cli

--- a/commands/geopos.md
+++ b/commands/geopos.md
@@ -4,16 +4,6 @@ Given a sorted set representing a geospatial index, populated using the `GEOADD`
 
 The command can accept a variable number of arguments so it always returns an array of positions even when a single element is specified.
 
-@return
-
-@array-reply, specifically:
-
-The command returns an array where each element is a two elements array
-representing longitude and latitude (x,y) of each member name passed as
-argument to the command.
-
-Non existing elements are reported as NULL elements of the array.
-
 @examples
 
 ```cli

--- a/commands/georadius.md
+++ b/commands/georadius.md
@@ -33,23 +33,6 @@ By default the command returns the items to the client. It is possible to store 
 * `!STORE`: Store the items in a sorted set populated with their geospatial information.
 * `!STOREDIST`: Store the items in a sorted set populated with their distance from the center as a floating point number, in the same unit specified in the radius.
 
-@return
-
-@array-reply, specifically:
-
-* Without any `WITH` option specified, the command just returns a linear array like ["New York","Milan","Paris"].
-* If `WITHCOORD`, `WITHDIST` or `WITHHASH` options are specified, the command returns an array of arrays, where each sub-array represents a single item.
-
-When additional information is returned as an array of arrays for each item, the first item in the sub-array is always the name of the returned item. The other information is returned in the following order as successive elements of the sub-array.
-
-1. The distance from the center as a floating point number, in the same unit specified in the radius.
-2. The geohash integer.
-3. The coordinates as a two items x,y array (longitude,latitude).
-
-So for example the command `GEORADIUS Sicily 15 37 200 km WITHCOORD WITHDIST` will return each item in the following way:
-
-    ["Palermo","190.4424",["13.361389338970184","38.115556395496299"]]
-
 ## Read-only variants
 
 Since `GEORADIUS` and `GEORADIUSBYMEMBER` have a `STORE` and `STOREDIST` option they are technically flagged as writing commands in the Redis command table. For this reason read-only replicas will flag them, and Redis Cluster replicas will redirect them to the master instance even if the connection is in read-only mode (see the `READONLY` command of Redis Cluster).

--- a/commands/georadius_ro.md
+++ b/commands/georadius_ro.md
@@ -1,7 +1,3 @@
 Read-only variant of the `GEORADIUS` command.
 
 This command is identical to the `GEORADIUS` command, except that it doesn't support the optional `STORE` and `STOREDIST` parameters.
-
-@return
-
-@array-reply: An array with each entry being the corresponding result of the subcommand given at the same position.

--- a/commands/geosearch.md
+++ b/commands/geosearch.md
@@ -28,19 +28,6 @@ When the `ANY` option is used, the command returns as soon as enough matches are
 When `ANY` is not provided, the command will perform an effort that is proportional to the number of items matching the specified area and sort them,
 so to query very large areas with a very small `COUNT` option may be slow even if just a few results are returned.
 
-@return
-
-@array-reply, specifically:
-
-* Without any `WITH` option specified, the command just returns a linear array like ["New York","Milan","Paris"].
-* If `WITHCOORD`, `WITHDIST` or `WITHHASH` options are specified, the command returns an array of arrays, where each sub-array represents a single item.
-
-When additional information is returned as an array of arrays for each item, the first item in the sub-array is always the name of the returned item. The other information is returned in the following order as successive elements of the sub-array.
-
-1. The distance from the center as a floating point number, in the same unit specified in the shape.
-2. The geohash integer.
-3. The coordinates as a two items x,y array (longitude,latitude).
-
 @examples
 
 ```cli

--- a/commands/geosearchstore.md
+++ b/commands/geosearchstore.md
@@ -6,10 +6,6 @@ By default, it stores the results in the `destination` sorted set with their geo
 
 When using the `STOREDIST` option, the command stores the items in a sorted set populated with their distance from the center of the circle or box, as a floating-point number, in the same unit specified for that shape.
 
-@return
-
-@integer-reply: the number of elements in the resulting set.
-
 @examples
 
 ```cli

--- a/commands/get.md
+++ b/commands/get.md
@@ -3,10 +3,6 @@ If the key does not exist the special value `nil` is returned.
 An error is returned if the value stored at `key` is not a string, because `GET`
 only handles string values.
 
-@return
-
-@bulk-string-reply: the value of `key`, or `nil` when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/getbit.md
+++ b/commands/getbit.md
@@ -6,10 +6,6 @@ When _key_ does not exist it is assumed to be an empty string, so _offset_ is
 always out of range and the value is also assumed to be a contiguous space with
 0 bits.
 
-@return
-
-@integer-reply: the bit value stored at _offset_.
-
 @examples
 
 ```cli

--- a/commands/getdel.md
+++ b/commands/getdel.md
@@ -1,10 +1,6 @@
 Get the value of `key` and delete the key.
 This command is similar to `GET`, except for the fact that it also deletes the key on success (if and only if the key's value type is a string).
 
-@return
-
-@bulk-string-reply: the value of `key`, `nil` when `key` does not exist, or an error if the key's value type isn't a string.
-
 @examples
 
 ```cli

--- a/commands/getex.md
+++ b/commands/getex.md
@@ -11,10 +11,6 @@ The `GETEX` command supports a set of options that modify its behavior:
 * `PXAT` *timestamp-milliseconds* -- Set the specified Unix time at which the key will expire, in milliseconds.
 * `PERSIST` -- Remove the time to live associated with the key.
 
-@return
-
-@bulk-string-reply: the value of `key`, or `nil` when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/getrange.md
+++ b/commands/getrange.md
@@ -7,10 +7,6 @@ So -1 means the last character, -2 the penultimate and so forth.
 The function handles out of range requests by limiting the resulting range to
 the actual length of the string.
 
-@return
-
-@bulk-string-reply
-
 @examples
 
 ```cli

--- a/commands/getset.md
+++ b/commands/getset.md
@@ -17,10 +17,6 @@ GETSET mycounter "0"
 GET mycounter
 ```
 
-@return
-
-@bulk-string-reply: the old value stored at `key`, or `nil` when `key` did not exist.
-
 @examples
 
 ```cli

--- a/commands/hdel.md
+++ b/commands/hdel.md
@@ -3,11 +3,6 @@ Specified fields that do not exist within this hash are ignored.
 If `key` does not exist, it is treated as an empty hash and this command returns
 `0`.
 
-@return
-
-@integer-reply: the number of fields that were removed from the hash, not
-including specified but non existing fields.
-
 @examples
 
 ```cli

--- a/commands/hello.md
+++ b/commands/hello.md
@@ -55,7 +55,3 @@ protocol to the specified version and also accepts the following options:
 
 * `AUTH <username> <password>`: directly authenticate the connection in addition to switching to the specified protocol version. This makes calling `AUTH` before `HELLO` unnecessary when setting up a new connection. Note that the `username` can be set to "default" to authenticate against a server that does not use ACLs, but rather the simpler `requirepass` mechanism of Redis prior to version 6.
 * `SETNAME <clientname>`: this is the equivalent of calling `CLIENT SETNAME`.
-
-@return
-
-@array-reply: a list of server properties. The reply is a map instead of an array when RESP3 is selected. The command returns an error if the `protover` requested does not exist.

--- a/commands/hexists.md
+++ b/commands/hexists.md
@@ -1,12 +1,5 @@
 Returns if `field` is an existing field in the hash stored at `key`.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the hash contains `field`.
-* `0` if the hash does not contain `field`, or `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/hget.md
+++ b/commands/hget.md
@@ -1,10 +1,5 @@
 Returns the value associated with `field` in the hash stored at `key`.
 
-@return
-
-@bulk-string-reply: the value associated with `field`, or `nil` when `field` is not
-present in the hash or `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/hgetall.md
+++ b/commands/hgetall.md
@@ -2,11 +2,6 @@ Returns all fields and values of the hash stored at `key`.
 In the returned value, every field name is followed by its value, so the length
 of the reply is twice the size of the hash.
 
-@return
-
-@array-reply: list of fields and their values stored in the hash, or an
-empty list when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/hincrby.md
+++ b/commands/hincrby.md
@@ -6,10 +6,6 @@ performed.
 
 The range of values supported by `HINCRBY` is limited to 64 bit signed integers.
 
-@return
-
-@integer-reply: the value at `field` after the increment operation.
-
 @examples
 
 Since the `increment` argument is signed, both increment and decrement

--- a/commands/hincrbyfloat.md
+++ b/commands/hincrbyfloat.md
@@ -12,10 +12,6 @@ The exact behavior of this command is identical to the one of the `INCRBYFLOAT`
 command, please refer to the documentation of `INCRBYFLOAT` for further
 information.
 
-@return
-
-@bulk-string-reply: the value of `field` after the increment.
-
 @examples
 
 ```cli

--- a/commands/hkeys.md
+++ b/commands/hkeys.md
@@ -1,10 +1,5 @@
 Returns all field names in the hash stored at `key`.
 
-@return
-
-@array-reply: list of fields in the hash, or an empty list when `key` does
-not exist.
-
 @examples
 
 ```cli

--- a/commands/hlen.md
+++ b/commands/hlen.md
@@ -1,9 +1,5 @@
 Returns the number of fields contained in the hash stored at `key`.
 
-@return
-
-@integer-reply: number of fields in the hash, or `0` when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/hmget.md
+++ b/commands/hmget.md
@@ -5,11 +5,6 @@ For every `field` that does not exist in the hash, a `nil` value is returned.
 Because non-existing keys are treated as empty hashes, running `HMGET` against
 a non-existing `key` will return a list of `nil` values.
 
-@return
-
-@array-reply: list of values associated with the given fields, in the same
-order as they are requested.
-
 ```cli
 HSET myhash field1 "Hello"
 HSET myhash field2 "World"

--- a/commands/hmset.md
+++ b/commands/hmset.md
@@ -3,10 +3,6 @@ Sets the specified fields to their respective values in the hash stored at
 This command overwrites any specified fields already existing in the hash.
 If `key` does not exist, a new key holding a hash is created.
 
-@return
-
-@simple-string-reply
-
 @examples
 
 ```cli

--- a/commands/hrandfield.md
+++ b/commands/hrandfield.md
@@ -8,13 +8,6 @@ In this case, the number of returned fields is the absolute value of the specifi
 
 The optional `WITHVALUES` modifier changes the reply so it includes the respective values of the randomly selected hash fields.
 
-@return
-
-@bulk-string-reply: without the additional `count` argument, the command returns a Bulk Reply with the randomly selected field, or `nil` when `key` does not exist.
-
-@array-reply: when the additional `count` argument is passed, the command returns an array of fields, or an empty array when `key` does not exist.
-If the `WITHVALUES` modifier is used, the reply is a list fields and their values from the hash.
-
 @examples
 
 ```cli

--- a/commands/hset.md
+++ b/commands/hset.md
@@ -3,10 +3,6 @@ Sets the specified fields to their respective values in the hash stored at `key`
 This command overwrites the values of specified fields that exist in the hash.
 If `key` doesn't exist, a new key holding a hash is created.
 
-@return
-
-@integer-reply: The number of fields that were added.
-
 @examples
 
 ```cli

--- a/commands/hsetnx.md
+++ b/commands/hsetnx.md
@@ -3,13 +3,6 @@ yet exist.
 If `key` does not exist, a new key holding a hash is created.
 If `field` already exists, this operation has no effect.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if `field` is a new field in the hash and `value` was set.
-* `0` if `field` already exists in the hash and no operation was performed.
-
 @examples
 
 ```cli

--- a/commands/hstrlen.md
+++ b/commands/hstrlen.md
@@ -1,9 +1,5 @@
 Returns the string length of the value associated with `field` in the hash stored at `key`. If the `key` or the `field` do not exist, 0 is returned.
 
-@return
-
-@integer-reply: the string length of the value associated with `field`, or zero when `field` is not present in the hash or `key` does not exist at all.
-
 @examples
 
 ```cli

--- a/commands/hvals.md
+++ b/commands/hvals.md
@@ -1,10 +1,5 @@
 Returns all values in the hash stored at `key`.
 
-@return
-
-@array-reply: list of values in the hash, or an empty list when `key` does
-not exist.
-
 @examples
 
 ```cli

--- a/commands/incr.md
+++ b/commands/incr.md
@@ -13,10 +13,6 @@ Redis stores integers in their integer representation, so for string values
 that actually hold an integer, there is no overhead for storing the string
 representation of the integer.
 
-@return
-
-@integer-reply: the value of `key` after the increment
-
 @examples
 
 ```cli

--- a/commands/incrby.md
+++ b/commands/incrby.md
@@ -6,10 +6,6 @@ This operation is limited to 64 bit signed integers.
 
 See `INCR` for extra information on increment/decrement operations.
 
-@return
-
-@integer-reply: the value of `key` after the increment
-
 @examples
 
 ```cli

--- a/commands/incrbyfloat.md
+++ b/commands/incrbyfloat.md
@@ -23,10 +23,6 @@ Trailing zeroes are always removed.
 The precision of the output is fixed at 17 digits after the decimal point
 regardless of the actual internal precision of the computation.
 
-@return
-
-@bulk-string-reply: the value of `key` after the increment.
-
 @examples
 
 ```cli

--- a/commands/info.md
+++ b/commands/info.md
@@ -26,13 +26,6 @@ It can also take the following values:
 
 When no parameter is provided, the `default` option is assumed.
 
-@return
-
-@bulk-string-reply: as a collection of text lines.
-
-Lines can contain a section name (starting with a # character) or a property.
-All the properties are in the form of `field:value` terminated by `\r\n`.
-
 ```cli
 INFO
 ```

--- a/commands/keys.md
+++ b/commands/keys.md
@@ -26,10 +26,6 @@ Supported glob-style patterns:
 
 Use `\` to escape special characters if you want to match them verbatim.
 
-@return
-
-@array-reply: list of keys matching `pattern`.
-
 @examples
 
 ```cli

--- a/commands/lastsave.md
+++ b/commands/lastsave.md
@@ -2,7 +2,3 @@ Return the UNIX TIME of the last DB save executed with success.
 A client may check if a `BGSAVE` command succeeded reading the `LASTSAVE` value,
 then issuing a `BGSAVE` command and checking at regular intervals every N
 seconds if `LASTSAVE` changed. Redis considers the database saved successfully at startup.
-
-@return
-
-@integer-reply: an UNIX time stamp.

--- a/commands/latency-doctor.md
+++ b/commands/latency-doctor.md
@@ -39,7 +39,3 @@ I have a few advices for you:
 For more information refer to the [Latency Monitoring Framework page][lm].
 
 [lm]: /topics/latency-monitor
-
-@return
-
-@bulk-string-reply

--- a/commands/latency-graph.md
+++ b/commands/latency-graph.md
@@ -58,7 +58,3 @@ in the lower row) is the minimum, and a # in the higher row is the maximum.
 For more information refer to the [Latency Monitoring Framework page][lm].
 
 [lm]: /topics/latency-monitor
-
-@return
-
-@bulk-string-reply

--- a/commands/latency-help.md
+++ b/commands/latency-help.md
@@ -4,7 +4,3 @@ subcommands.
 For more information refer to the [Latency Monitoring Framework page][lm].
 
 [lm]: /topics/latency-monitor
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/latency-histogram.md
+++ b/commands/latency-histogram.md
@@ -34,10 +34,3 @@ To delete the latency histograms' data use the `CONFIG RESETSTAT` command.
       5# (integer) 16 => (integer) 99968
       6# (integer) 33 => (integer) 100000
 ```
-
-@return
-
-@array-reply: specifically:
-
-The command returns a map where each key is a command name.
-The value is a map with a key for the total calls, and a map of the histogram time buckets.

--- a/commands/latency-history.md
+++ b/commands/latency-history.md
@@ -35,10 +35,3 @@ Valid values for `event` are:
 For more information refer to the [Latency Monitoring Framework page][lm].
 
 [lm]: /topics/latency-monitor
-
-@return
-
-@array-reply: specifically:
-
-The command returns an array where each element is a two elements array
-representing the timestamp and the latency of the event.

--- a/commands/latency-latest.md
+++ b/commands/latency-latest.md
@@ -28,10 +28,3 @@ OK
 For more information refer to the [Latency Monitoring Framework page][lm].
 
 [lm]: /topics/latency-monitor
-
-@return
-
-@array-reply: specifically:
-
-The command returns an array where each element is a four elements array
-representing the event's name, timestamp, latest and all-time latency measurements.

--- a/commands/latency-reset.md
+++ b/commands/latency-reset.md
@@ -28,7 +28,3 @@ Valid values for `event` are:
 For more information refer to the [Latency Monitoring Framework page][lm].
 
 [lm]: /topics/latency-monitor
-
-@return
-
-@integer-reply: the number of event time series that were reset.

--- a/commands/lcs.md
+++ b/commands/lcs.md
@@ -70,10 +70,3 @@ Finally to also have the match len:
 3) "len"
 4) (integer) 6
 ```
-
-@return
-
-* Without modifiers the string representing the longest common substring is returned.
-* When `LEN` is given the command returns the length of the longest common substring.
-* When `IDX` is given the command returns an array with the LCS length and all the ranges in both the strings, start and end offset for each string, where there are matches. When `WITHMATCHLEN` is given each array representing a match will also have the length of the match (see examples).
-

--- a/commands/lindex.md
+++ b/commands/lindex.md
@@ -7,10 +7,6 @@ Here, `-1` means the last element, `-2` means the penultimate and so forth.
 
 When the value at `key` is not a list, an error is returned.
 
-@return
-
-@bulk-string-reply: the requested element, or `nil` when `index` is out of range.
-
 @examples
 
 ```cli

--- a/commands/linsert.md
+++ b/commands/linsert.md
@@ -6,10 +6,6 @@ performed.
 
 An error is returned when `key` exists but does not hold a list value.
 
-@return
-
-@integer-reply: the list length after a successful insert operation, `0` if the `key` doesn't exist, and `-1` when the `pivot` wasn't found.
-
 @examples
 
 ```cli

--- a/commands/llen.md
+++ b/commands/llen.md
@@ -2,10 +2,6 @@ Returns the length of the list stored at `key`.
 If `key` does not exist, it is interpreted as an empty list and `0` is returned.
 An error is returned when the value stored at `key` is not a list.
 
-@return
-
-@integer-reply: the length of the list at `key`.
-
 @examples
 
 ```cli

--- a/commands/lmove.md
+++ b/commands/lmove.md
@@ -18,10 +18,6 @@ no-op if `wherefrom` is the same as `whereto`).
 This command comes in place of the now deprecated `RPOPLPUSH`. Doing
 `LMOVE RIGHT LEFT` is equivalent.
 
-@return
-
-@bulk-string-reply: the element being popped and pushed.
-
 @examples
 
 ```cli

--- a/commands/lmpop.md
+++ b/commands/lmpop.md
@@ -10,13 +10,6 @@ See `BLMPOP` for the blocking variant of this command.
 Elements are popped from either the left or right of the first non-empty list based on the passed argument.
 The number of returned elements is limited to the lower between the non-empty list's length, and the count argument (which defaults to 1).
 
-@return
-
-@array-reply: specifically:
-
-* A `nil` when no element could be popped.
-* A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of elements.
-
 @examples
 
 ```cli

--- a/commands/lolwut.md
+++ b/commands/lolwut.md
@@ -23,7 +23,3 @@ LOLWUT version should have the following properties:
 3. LOLWUT output should be fast to generate so that the command can be called in production instances without issues. It should remain fast even when the user experiments with odd parameters.
 4. LOLWUT implementations should be safe and carefully checked for security, and resist to untrusted inputs if they take arguments.
 5. LOLWUT must always display the Redis version at the end.
-
-@return
-
-@bulk-string-reply (or verbatim reply when using the RESP3 protocol): the string containing the generative computer art, and a text with the Redis version.

--- a/commands/lpop.md
+++ b/commands/lpop.md
@@ -4,16 +4,6 @@ By default, the command pops a single element from the beginning of the list.
 When provided with the optional `count` argument, the reply will consist of up
 to `count` elements, depending on the list's length.
 
-@return
-
-When called without the `count` argument:
-
-@bulk-string-reply: the value of the first element, or `nil` when `key` does not exist.
-
-When called with the `count` argument:
-
-@array-reply: list of popped elements, or `nil` when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/lpos.md
+++ b/commands/lpos.md
@@ -57,10 +57,6 @@ Finally, the `MAXLEN` option tells the command to compare the provided element o
 
 When `MAXLEN` is used, it is possible to specify 0 as the maximum number of comparisons, as a way to tell the command we want unlimited comparisons. This is better than giving a very large `MAXLEN` option because it is more general.
 
-@return
-
-The command returns the integer representing the matching element, or `nil` if there is no match. However, if the `COUNT` option is given the command returns an array (empty if there are no matches).
-
 @examples
 
 ```cli

--- a/commands/lpush.md
+++ b/commands/lpush.md
@@ -10,10 +10,6 @@ leftmost element to the rightmost element.
 So for instance the command `LPUSH mylist a b c` will result into a list
 containing `c` as first element, `b` as second element and `a` as third element.
 
-@return
-
-@integer-reply: the length of the list after the push operations.
-
 @examples
 
 ```cli

--- a/commands/lpushx.md
+++ b/commands/lpushx.md
@@ -3,10 +3,6 @@ already exists and holds a list.
 In contrary to `LPUSH`, no operation will be performed when `key` does not yet
 exist.
 
-@return
-
-@integer-reply: the length of the list after the push operation.
-
 @examples
 
 ```cli

--- a/commands/lrange.md
+++ b/commands/lrange.md
@@ -23,10 +23,6 @@ If `start` is larger than the end of the list, an empty list is returned.
 If `stop` is larger than the actual end of the list, Redis will treat it like
 the last element of the list.
 
-@return
-
-@array-reply: list of elements in the specified range.
-
 @examples
 
 ```cli

--- a/commands/lrem.md
+++ b/commands/lrem.md
@@ -12,10 +12,6 @@ For example, `LREM list -2 "hello"` will remove the last two occurrences of
 Note that non-existing keys are treated like empty lists, so when `key` does not
 exist, the command will always return `0`.
 
-@return
-
-@integer-reply: the number of removed elements.
-
 @examples
 
 ```cli

--- a/commands/lset.md
+++ b/commands/lset.md
@@ -3,10 +3,6 @@ For more information on the `index` argument, see `LINDEX`.
 
 An error is returned for out of range indexes.
 
-@return
-
-@simple-string-reply
-
 @examples
 
 ```cli

--- a/commands/ltrim.md
+++ b/commands/ltrim.md
@@ -31,10 +31,6 @@ It is important to note that when used in this way `LTRIM` is an O(1) operation
 because in the average case just one element is removed from the tail of the
 list.
 
-@return
-
-@simple-string-reply
-
 @examples
 
 ```cli

--- a/commands/memory-doctor.md
+++ b/commands/memory-doctor.md
@@ -1,6 +1,2 @@
 The `MEMORY DOCTOR` command reports about different memory-related issues that
 the Redis server experiences, and advises about possible remedies.
-
-@return
-
-@bulk-string-reply 

--- a/commands/memory-help.md
+++ b/commands/memory-help.md
@@ -1,6 +1,2 @@
 The `MEMORY HELP` command returns a helpful text describing the different
 subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/memory-malloc-stats.md
+++ b/commands/memory-malloc-stats.md
@@ -3,7 +3,3 @@ the memory allocator.
 
 This command is currently implemented only when using **jemalloc** as an
 allocator, and evaluates to a benign NOOP for all others.
-
-@return
-
-@bulk-string-reply: the memory allocator's internal statistics report

--- a/commands/memory-purge.md
+++ b/commands/memory-purge.md
@@ -3,7 +3,3 @@ reclaimed by the allocator.
 
 This command is currently implemented only when using **jemalloc** as an
 allocator, and evaluates to a benign NOOP for all others.
-
-@return
-
-@simple-string-reply

--- a/commands/memory-stats.md
+++ b/commands/memory-stats.md
@@ -39,8 +39,4 @@ values. The following metrics are reported:
      `peak.allocated`
 *   `fragmentation`: See `INFO`'s `mem_fragmentation_ratio`
 
-@return
-
-@array-reply: nested list of memory usage metrics and their values
-
 **A note about the word slave used in this man page**: Starting with Redis 5, if not for backward compatibility, the Redis project no longer uses the word slave. Unfortunately in this command the word slave is part of the protocol, so we'll be able to remove such occurrences only when this API will be naturally deprecated.

--- a/commands/memory-usage.md
+++ b/commands/memory-usage.md
@@ -37,7 +37,3 @@ OK
 > MEMORY USAGE foo3
 (integer) 160
 ```
-
-@return
-
-@integer-reply: the memory usage in bytes, or `nil` when the key does not exist.

--- a/commands/mget.md
+++ b/commands/mget.md
@@ -3,10 +3,6 @@ For every key that does not hold a string value or does not exist, the special
 value `nil` is returned.
 Because of this, the operation never fails.
 
-@return
-
-@array-reply: list of values at the specified keys.
-
 @examples
 
 ```cli

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -65,8 +65,3 @@ just a single key exists.
 * `!KEYS` -- If the key argument is an empty string, the command will instead migrate all the keys that follow the `!KEYS` option (see the above section for more info).
 * `!AUTH` -- Authenticate with the given password to the remote instance.
 * `AUTH2` -- Authenticate with the given username and password pair (Redis 6 or greater ACL auth style).
-
-@return
-
-@simple-string-reply: The command returns OK on success, or `NOKEY` if no keys were
-found in the source instance.

--- a/commands/module-help.md
+++ b/commands/module-help.md
@@ -1,5 +1,1 @@
 The `MODULE HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/module-list.md
+++ b/commands/module-list.md
@@ -1,10 +1,1 @@
 Returns information about the modules loaded to the server.
-
-@return
-
-@array-reply: list of loaded modules. Each element in the list represents a
-module, and is in itself a list of property names and their values. The
-following properties is reported for each loaded module:
-
-*   `name`: Name of the module
-*   `ver`: Version of the module

--- a/commands/module-load.md
+++ b/commands/module-load.md
@@ -7,7 +7,3 @@ unmodified to the module.
 
 **Note**: modules can also be loaded at server startup with `loadmodule`
 configuration directive in `redis.conf`.
-
-@return
-
-@simple-string-reply: `OK` if module was loaded.

--- a/commands/module-loadex.md
+++ b/commands/module-loadex.md
@@ -9,7 +9,3 @@ Any additional arguments that follow the `ARGS` keyword are passed unmodified to
 
 **Note**: modules can also be loaded at server startup with `loadmodule`
 configuration directive in `redis.conf`.
-
-@return
-
-@simple-string-reply: `OK` if module was loaded.

--- a/commands/module-unload.md
+++ b/commands/module-unload.md
@@ -7,7 +7,3 @@ library's filename.
 Known limitations:
 
 *   Modules that register custom data types can not be unloaded.
-
-@return
-
-@simple-string-reply: `OK` if module was unloaded.

--- a/commands/monitor.md
+++ b/commands/monitor.md
@@ -80,11 +80,6 @@ In this particular case, running a single `MONITOR` client can reduce the
 throughput by more than 50%.
 Running more `MONITOR` clients will reduce throughput even more.
 
-@return
-
-**Non standard return value**, just dumps the received commands in an infinite
-flow.
-
 ## Behavior change history
 
 *   `>= 6.0.0`: `AUTH` excluded from the command's output.

--- a/commands/move.md
+++ b/commands/move.md
@@ -3,10 +3,3 @@ destination database.
 When `key` already exists in the destination database, or it does not exist in
 the source database, it does nothing.
 It is possible to use `MOVE` as a locking primitive because of this.
-
-@return
-
-@integer-reply, specifically:
-
-* `1` if `key` was moved.
-* `0` if `key` was not moved.

--- a/commands/mset.md
+++ b/commands/mset.md
@@ -6,10 +6,6 @@ See `MSETNX` if you don't want to overwrite existing values.
 It is not possible for clients to see that some of the keys were updated while
 others are unchanged.
 
-@return
-
-@simple-string-reply: always `OK` since `MSET` can't fail.
-
 @examples
 
 ```cli

--- a/commands/msetnx.md
+++ b/commands/msetnx.md
@@ -10,13 +10,6 @@ that either all the fields or none at all are set.
 It is not possible for clients to see that some of the keys were updated while
 others are unchanged.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the all the keys were set.
-* `0` if no key was set (at least one key already existed).
-
 @examples
 
 ```cli

--- a/commands/multi.md
+++ b/commands/multi.md
@@ -2,7 +2,3 @@ Marks the start of a [transaction][tt] block.
 Subsequent commands will be queued for atomic execution using `EXEC`.
 
 [tt]: /topics/transactions
-
-@return
-
-@simple-string-reply: always `OK`.

--- a/commands/object-encoding.md
+++ b/commands/object-encoding.md
@@ -15,7 +15,3 @@ Redis objects can be encoded in different ways:
 * Sorted Sets can be encoded as `ziplist` or `skiplist` format. As for the List type small sorted sets can be specially encoded using `ziplist`, while the `skiplist` encoding is the one that works with sorted sets of any size.
 
 All the specially encoded types are automatically converted to the general type once you perform an operation that makes it impossible for Redis to retain the space saving encoding.
-
-@return
-
-@bulk-string-reply: the encoding of the object, or `nil` if the key doesn't exist

--- a/commands/object-freq.md
+++ b/commands/object-freq.md
@@ -1,9 +1,3 @@
 This command returns the logarithmic access frequency counter of a Redis object stored at `<key>`.
 
 The command is only available when the `maxmemory-policy` configuration directive is set to one of the LFU policies.
-
-@return
-
-@integer-reply
-
-The counter's value.

--- a/commands/object-help.md
+++ b/commands/object-help.md
@@ -1,5 +1,1 @@
 The `OBJECT HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/object-idletime.md
+++ b/commands/object-idletime.md
@@ -1,9 +1,3 @@
 This command returns the time in seconds since the last access to the value stored at `<key>`.
 
 The command is only available when the `maxmemory-policy` configuration directive is not set to one of the LFU policies.
-
-@return
-
-@integer-reply
-
-The idle time in seconds.

--- a/commands/object-refcount.md
+++ b/commands/object-refcount.md
@@ -1,7 +1,1 @@
 This command returns the reference count of the stored at `<key>`.
-
-@return
-
-@integer-reply
-
-The number of references.

--- a/commands/persist.md
+++ b/commands/persist.md
@@ -2,13 +2,6 @@ Remove the existing timeout on `key`, turning the key from _volatile_ (a key
 with an expire set) to _persistent_ (a key that will never expire as no timeout
 is associated).
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the timeout was removed.
-* `0` if `key` does not exist or does not have an associated timeout.
-
 @examples
 
 ```cli

--- a/commands/pexpire.md
+++ b/commands/pexpire.md
@@ -13,13 +13,6 @@ The `PEXPIRE` command supports a set of options since Redis 7.0:
 A non-volatile key is treated as an infinite TTL for the purpose of `GT` and `LT`.
 The `GT`, `LT` and `NX` options are mutually exclusive.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the timeout was set.
-* `0` if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.
-
 @examples
 
 ```cli

--- a/commands/pexpireat.md
+++ b/commands/pexpireat.md
@@ -13,13 +13,6 @@ The `PEXPIREAT` command supports a set of options since Redis 7.0:
 A non-volatile key is treated as an infinite TTL for the purpose of `GT` and `LT`.
 The `GT`, `LT` and `NX` options are mutually exclusive.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the timeout was set.
-* `0` if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.
-
 @examples
 
 ```cli

--- a/commands/pexpiretime.md
+++ b/commands/pexpiretime.md
@@ -1,12 +1,5 @@
 `PEXPIRETIME` has the same semantic as `EXPIRETIME`, but returns the absolute Unix expiration timestamp in milliseconds instead of seconds.
 
-@return
-
-@integer-reply: Expiration Unix timestamp in milliseconds, or a negative value in order to signal an error (see the description below).
-
-* The command returns `-1` if the key exists but has no associated expiration time.
-* The command returns `-2` if the key does not exist.
-
 @examples
 
 ```cli

--- a/commands/pfadd.md
+++ b/commands/pfadd.md
@@ -8,12 +8,6 @@ To call the command without elements but just the variable name is valid, this w
 
 For an introduction to HyperLogLog data structure check the `PFCOUNT` command page.
 
-@return
-
-@integer-reply, specifically:
-
-* 1 if at least 1 HyperLogLog internal register was altered. 0 otherwise.
-
 @examples
 
 ```cli

--- a/commands/pfcount.md
+++ b/commands/pfcount.md
@@ -11,12 +11,6 @@ For example in order to take the count of all the unique search queries performe
 Note: as a side effect of calling this function, it is possible that the HyperLogLog is modified, since the last 8 bytes encode the latest computed cardinality
 for caching purposes. So `PFCOUNT` is technically a write command.
 
-@return
-
-@integer-reply, specifically:
-
-* The approximated number of unique elements observed via `PFADD`.
-
 @examples
 
 ```cli

--- a/commands/pfmerge.md
+++ b/commands/pfmerge.md
@@ -9,10 +9,6 @@ If the destination variable exists, it is treated as one of the source sets
 and its cardinality will be included in the cardinality of the computed
 HyperLogLog.
 
-@return
-
-@simple-string-reply: The command just returns `OK`.
-
 @examples
 
 ```cli

--- a/commands/ping.md
+++ b/commands/ping.md
@@ -10,12 +10,6 @@ multi-bulk with a "pong" in the first position and an empty bulk in the second
 position, unless an argument is provided in which case it returns a copy
 of the argument.
 
-@return
-
-@simple-string-reply, and specifically `PONG`, when no argument is provided.
-
-@bulk-string-reply the argument provided, when applicable.
-
 @examples
 
 ```cli

--- a/commands/psubscribe.md
+++ b/commands/psubscribe.md
@@ -13,11 +13,6 @@ However, if RESP3 is used (see `HELLO`) it is possible for a client to issue any
 
 For more information, see [Pub/sub](/docs/interact/pubsub/).
 
-@return
-
-When successful, this command doesn't return anything.
-Instead, for each pattern, one message with the first element being the string "psubscribe" is pushed as a confirmation that the command succeeded.
-
 ## Behavior change history
 
 *   `>= 6.2.0`: `RESET` can be called to exit subscribed state.

--- a/commands/psync.md
+++ b/commands/psync.md
@@ -7,7 +7,3 @@ For more information about replication in Redis please check the
 [replication page][tr].
 
 [tr]: /topics/replication
-
-@return
-
-**Non standard return value**, a bulk transfer of the data followed by `PING` and write requests from the master.

--- a/commands/pttl.md
+++ b/commands/pttl.md
@@ -9,10 +9,6 @@ Starting with Redis 2.8 the return value in case of error changed:
 * The command returns `-2` if the key does not exist.
 * The command returns `-1` if the key exists but has no associated expire.
 
-@return
-
-@integer-reply: TTL in milliseconds, or a negative value in order to signal an error (see the description above).
-
 @examples
 
 ```cli

--- a/commands/publish.md
+++ b/commands/publish.md
@@ -3,9 +3,3 @@ Posts a message to the given channel.
 In a Redis Cluster clients can publish to every node. The cluster makes sure
 that published messages are forwarded as needed, so clients can subscribe to any
 channel by connecting to any one of the nodes.
-
-@return
-
-@integer-reply: the number of clients that received the message. Note that in a
-Redis Cluster, only clients that are connected to the same node as the
-publishing client are included in the count.

--- a/commands/pubsub-channels.md
+++ b/commands/pubsub-channels.md
@@ -5,7 +5,3 @@ An active channel is a Pub/Sub channel with one or more subscribers (excluding c
 If no `pattern` is specified, all the channels are listed, otherwise if pattern is specified only channels matching the specified glob-style pattern are listed.
 
 Cluster note: in a Redis Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, `PUBSUB`'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
-
-@return
-
-@array-reply: a list of active channels, optionally matching the specified pattern.

--- a/commands/pubsub-help.md
+++ b/commands/pubsub-help.md
@@ -1,5 +1,1 @@
 The `PUBSUB HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/pubsub-numpat.md
+++ b/commands/pubsub-numpat.md
@@ -3,7 +3,3 @@ Returns the number of unique patterns that are subscribed to by clients (that ar
 Note that this isn't the count of clients subscribed to patterns, but the total number of unique patterns all the clients are subscribed to.
 
 Cluster note: in a Redis Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, `PUBSUB`'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
-
-@return
-
-@integer-reply: the number of patterns all the clients are subscribed to.

--- a/commands/pubsub-numsub.md
+++ b/commands/pubsub-numsub.md
@@ -3,9 +3,3 @@ Returns the number of subscribers (exclusive of clients subscribed to patterns) 
 Note that it is valid to call this command without channels. In this case it will just return an empty list.
 
 Cluster note: in a Redis Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, `PUBSUB`'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
-
-@return
-
-@array-reply: a list of channels and number of subscribers for every channel.
-
-The format is channel, count, channel, count, ..., so the list is flat. The order in which the channels are listed is the same as the order of the channels specified in the command call.

--- a/commands/pubsub-shardchannels.md
+++ b/commands/pubsub-shardchannels.md
@@ -6,10 +6,6 @@ If no `pattern` is specified, all the channels are listed, otherwise if pattern 
 
 The information returned about the active shard channels are at the shard level and not at the cluster level.
 
-@return
-
-@array-reply: a list of active channels, optionally matching the specified pattern.
-
 @examples
 
 ```

--- a/commands/pubsub-shardnumsub.md
+++ b/commands/pubsub-shardnumsub.md
@@ -4,12 +4,6 @@ Note that it is valid to call this command without channels, in this case it wil
 
 Cluster note: in a Redis Cluster, `PUBSUB`'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
 
-@return
-
-@array-reply: a list of channels and number of subscribers for every channel.
-
-The format is channel, count, channel, count, ..., so the list is flat. The order in which the channels are listed is the same as the order of the shard channels specified in the command call.
-
 @examples
 
 ```

--- a/commands/punsubscribe.md
+++ b/commands/punsubscribe.md
@@ -5,8 +5,3 @@ When no patterns are specified, the client is unsubscribed from all the
 previously subscribed patterns.
 In this case, a message for every unsubscribed pattern will be sent to the
 client.
-
-@return
-
-When successful, this command doesn't return anything.
-Instead, for each pattern, one message with the first element being the string "punsubscribe" is pushed as a confirmation that the command succeeded.

--- a/commands/quit.md
+++ b/commands/quit.md
@@ -5,7 +5,3 @@ client.
 **Note:** Clients should not use this command.
 Instead, clients should simply close the connection when they're not used anymore.
 Terminating a connection on the client side is preferable, as it eliminates `TIME_WAIT` lingering sockets on the server side.
-
-@return
-
-@simple-string-reply: always OK.

--- a/commands/randomkey.md
+++ b/commands/randomkey.md
@@ -1,5 +1,1 @@
 Return a random key from the currently selected database.
-
-@return
-
-@bulk-string-reply: the random key, or `nil` when the database is empty.

--- a/commands/readonly.md
+++ b/commands/readonly.md
@@ -13,7 +13,3 @@ master node. This may happen because:
 
 1. The client sent a command about hash slots never served by the master of this replica.
 2. The cluster was reconfigured (for example resharded) and the replica is no longer able to serve commands for a given hash slot.
-
-@return
-
-@simple-string-reply

--- a/commands/readwrite.md
+++ b/commands/readwrite.md
@@ -4,7 +4,3 @@ Read queries against a Redis Cluster replica node are disabled by default,
 but you can use the `READONLY` command to change this behavior on a per-
 connection basis. The `READWRITE` command resets the readonly mode flag
 of a connection back to readwrite.
-
-@return
-
-@simple-string-reply

--- a/commands/rename.md
+++ b/commands/rename.md
@@ -4,10 +4,6 @@ If `newkey` already exists it is overwritten, when this happens `RENAME` execute
 
 In Cluster mode, both `key` and `newkey` must be in the same **hash slot**, meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
 
-@return
-
-@simple-string-reply
-
 @examples
 
 ```cli

--- a/commands/renamenx.md
+++ b/commands/renamenx.md
@@ -3,13 +3,6 @@ It returns an error when `key` does not exist.
 
 In Cluster mode, both `key` and `newkey` must be in the same **hash slot**, meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if `key` was renamed to `newkey`.
-* `0` if `newkey` already exists.
-
 @examples
 
 ```cli

--- a/commands/replicaof.md
+++ b/commands/replicaof.md
@@ -6,10 +6,6 @@ If a server is already a replica of some master, `REPLICAOF` hostname port will 
 
 The form `REPLICAOF` NO ONE will stop replication, turning the server into a MASTER, but will not discard the replication. So, if the old master stops working, it is possible to turn the replica into a master and set the application to use this new master in read/write. Later when the other Redis server is fixed, it can be reconfigured to work as a replica.
 
-@return
-
-@simple-string-reply
-
 @examples
 
 ```

--- a/commands/reset.md
+++ b/commands/reset.md
@@ -19,7 +19,3 @@ following:
   authentication is enabled.
 * Turns off `NO-EVICT` mode.
 * Turns off `NO-TOUCH` mode.
-
-@return
-
-@simple-string-reply: always 'RESET'.

--- a/commands/restore.md
+++ b/commands/restore.md
@@ -18,10 +18,6 @@ exists unless you use the `REPLACE` modifier.
 `!RESTORE` checks the RDB version and data checksum.
 If they don't match an error is returned.
 
-@return
-
-@simple-string-reply: The command returns OK on success.
-
 @examples
 
 ```

--- a/commands/role.md
+++ b/commands/role.md
@@ -69,10 +69,6 @@ The sentinel output is composed of the following parts:
 1. The string `sentinel`.
 2. An array of master names monitored by this Sentinel instance.
 
-@return
-
-@array-reply: where the first element is one of `master`, `slave`, `sentinel` and the additional elements are role-specific as illustrated above.
-
 @examples
 
 ```cli

--- a/commands/rpop.md
+++ b/commands/rpop.md
@@ -4,16 +4,6 @@ By default, the command pops a single element from the end of the list.
 When provided with the optional `count` argument, the reply will consist of up
 to `count` elements, depending on the list's length.
 
-@return
-
-When called without the `count` argument:
-
-@bulk-string-reply: the value of the last element, or `nil` when `key` does not exist.
-
-When called with the `count` argument:
-
-@array-reply: list of popped elements, or `nil` when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/rpoplpush.md
+++ b/commands/rpoplpush.md
@@ -13,10 +13,6 @@ If `source` and `destination` are the same, the operation is equivalent to
 removing the last element from the list and pushing it as first element of the
 list, so it can be considered as a list rotation command.
 
-@return
-
-@bulk-string-reply: the element being popped and pushed.
-
 @examples
 
 ```cli

--- a/commands/rpush.md
+++ b/commands/rpush.md
@@ -10,10 +10,6 @@ leftmost element to the rightmost element.
 So for instance the command `RPUSH mylist a b c` will result into a list
 containing `a` as first element, `b` as second element and `c` as third element.
 
-@return
-
-@integer-reply: the length of the list after the push operation.
-
 @examples
 
 ```cli

--- a/commands/rpushx.md
+++ b/commands/rpushx.md
@@ -3,10 +3,6 @@ already exists and holds a list.
 In contrary to `RPUSH`, no operation will be performed when `key` does not yet
 exist.
 
-@return
-
-@integer-reply: the length of the list after the push operation.
-
 @examples
 
 ```cli

--- a/commands/sadd.md
+++ b/commands/sadd.md
@@ -5,11 +5,6 @@ members.
 
 An error is returned when the value stored at `key` is not a set.
 
-@return
-
-@integer-reply: the number of elements that were added to the set, not including
-all the elements already present in the set.
-
 @examples
 
 ```cli

--- a/commands/save.md
+++ b/commands/save.md
@@ -12,7 +12,3 @@ good last resort to perform the dump of the latest dataset.
 Please refer to the [persistence documentation][tp] for detailed information.
 
 [tp]: /topics/persistence
-
-@return
-
-@simple-string-reply: The commands returns OK on success.

--- a/commands/scard.md
+++ b/commands/scard.md
@@ -1,10 +1,5 @@
 Returns the set cardinality (number of elements) of the set stored at `key`.
 
-@return
-
-@integer-reply: the cardinality (number of elements) of the set, or `0` if `key`
-does not exist.
-
 @examples
 
 ```cli

--- a/commands/script-debug.md
+++ b/commands/script-debug.md
@@ -20,8 +20,3 @@ is active and retains all changes to the data set once it ends.
 * `NO`. Disables scripts debug mode.
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).
-
-@return
-
-@simple-string-reply: `OK`.
-

--- a/commands/script-exists.md
+++ b/commands/script-exists.md
@@ -9,10 +9,3 @@ operation can be performed solely using `EVALSHA` instead of `EVAL` to save
 bandwidth.
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).
-
-@return
-
-@array-reply The command returns an array of integers that correspond to
-the specified SHA1 digest arguments.
-For every corresponding SHA1 digest of a script that actually exists in the
-script cache, a 1 is returned, otherwise 0 is returned.

--- a/commands/script-flush.md
+++ b/commands/script-flush.md
@@ -10,10 +10,6 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).
 
-@return
-
-@simple-string-reply
-
 ## Behavior change history
 
 *   `>= 6.2.0`: Default flush behavior now configurable by the **lazyfree-lazy-user-flush** configuration directive. 

--- a/commands/script-help.md
+++ b/commands/script-help.md
@@ -1,5 +1,1 @@
 The `SCRIPT HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/script-kill.md
+++ b/commands/script-kill.md
@@ -13,7 +13,3 @@ the Redis process in a hard way and preventing it from persisting with half-writ
 information.
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).
-
-@return
-
-@simple-string-reply

--- a/commands/script-load.md
+++ b/commands/script-load.md
@@ -10,8 +10,3 @@ The command works in the same way even if the script was already present in the
 script cache.
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](/topics/eval-intro).
-
-@return
-
-@bulk-string-reply This command returns the SHA1 digest of the script added into the
-script cache.

--- a/commands/sdiff.md
+++ b/commands/sdiff.md
@@ -12,10 +12,6 @@ SDIFF key1 key2 key3 = {b,d}
 
 Keys that do not exist are considered to be empty sets.
 
-@return
-
-@array-reply: list with members of the resulting set.
-
 @examples
 
 ```cli

--- a/commands/sdiffstore.md
+++ b/commands/sdiffstore.md
@@ -3,10 +3,6 @@ is stored in `destination`.
 
 If `destination` already exists, it is overwritten.
 
-@return
-
-@integer-reply: the number of elements in the resulting set.
-
 @examples
 
 ```cli

--- a/commands/select.md
+++ b/commands/select.md
@@ -8,7 +8,3 @@ In practical terms, Redis databases should be used to separate different keys be
 When using Redis Cluster, the `SELECT` command cannot be used, since Redis Cluster only supports database zero. In the case of a Redis Cluster, having multiple databases would be useless and an unnecessary source of complexity. Commands operating atomically on a single database would not be possible with the Redis Cluster design and goals.
 
 Since the currently selected database is a property of the connection, clients should track the currently selected database and re-select it on reconnection. While there is no command in order to query the selected database in the current connection, the `CLIENT LIST` output shows, for each client, the currently selected database.
-
-@return
-
-@simple-string-reply

--- a/commands/set.md
+++ b/commands/set.md
@@ -17,18 +17,6 @@ The `SET` command supports a set of options that modify its behavior:
 
 Note: Since the `SET` command options can replace `SETNX`, `SETEX`, `PSETEX`, `GETSET`, it is possible that in future versions of Redis these commands will be deprecated and finally removed.
 
-@return
-
-@simple-string-reply: `OK` if `SET` was executed correctly.
-
-@nil-reply: `(nil)` if the `SET` operation was not performed because the user specified the `NX` or `XX` option but the condition was not met.
-
-If the command is issued with the `!GET` option, the above does not apply. It will instead reply as follows, regardless if the `SET` was actually performed:
-
-@bulk-string-reply: the old string value stored at key.
-
-@nil-reply: `(nil)` if the key did not exist.
-
 @examples
 
 ```cli

--- a/commands/setbit.md
+++ b/commands/setbit.md
@@ -20,10 +20,6 @@ allocation) takes ~8ms.
 Note that once this first allocation is done, subsequent calls to `SETBIT` for
 the same _key_ will not have the allocation overhead.
 
-@return
-
-@integer-reply: the original bit value stored at _offset_.
-
 @examples
 
 ```cli

--- a/commands/setex.md
+++ b/commands/setex.md
@@ -6,12 +6,7 @@ This command is equivalent to:
 SET key value EX seconds
 ```
 
-
 An error is returned when `seconds` is invalid.
-
-@return
-
-@simple-string-reply
 
 @examples
 

--- a/commands/setnx.md
+++ b/commands/setnx.md
@@ -3,13 +3,6 @@ In that case, it is equal to `SET`.
 When `key` already holds a value, no operation is performed.
 `SETNX` is short for "**SET** if **N**ot e**X**ists".
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the key was set
-* `0` if the key was not set
-
 @examples
 
 ```cli

--- a/commands/setrange.md
+++ b/commands/setrange.md
@@ -26,10 +26,6 @@ Thanks to `SETRANGE` and the analogous `GETRANGE` commands, you can use Redis
 strings as a linear array with O(1) random access.
 This is a very fast and efficient storage in many real world use cases.
 
-@return
-
-@integer-reply: the length of the string after it was modified by the command.
-
 @examples
 
 Basic usage:

--- a/commands/shutdown.md
+++ b/commands/shutdown.md
@@ -62,12 +62,6 @@ This provides a best effort minimizing the risk of data loss in a situation wher
 Before version 7.0, shutting down a heavily loaded master node in a diskless setup was more likely to result in data loss.
 To minimize the risk of data loss in such setups, it's advised to trigger a manual `FAILOVER` (or `CLUSTER FAILOVER`) to demote the master to a replica and promote one of the replicas to be the new master, before shutting down a master node.
 
-@return
-
-@simple-string-reply: `OK` if `ABORT` was specified and shutdown was aborted.
-On successful shutdown, nothing is returned since the server quits and the connection is closed.
-On failure, an error is returned.
-
 ## Behavior change history
 
 *   `>= 7.0.0`: Introduced waiting for lagging replicas before exiting.

--- a/commands/sinter.md
+++ b/commands/sinter.md
@@ -14,10 +14,6 @@ Keys that do not exist are considered to be empty sets.
 With one of the keys being an empty set, the resulting set is also empty (since
 set intersection with an empty set always results in an empty set).
 
-@return
-
-@array-reply: list with members of the resulting set.
-
 @examples
 
 ```cli

--- a/commands/sintercard.md
+++ b/commands/sintercard.md
@@ -8,10 +8,6 @@ By default, the command calculates the cardinality of the intersection of all gi
 When provided with the optional `LIMIT` argument (which defaults to 0 and means unlimited), if the intersection cardinality reaches limit partway through the computation, the algorithm will exit and yield limit as the cardinality.
 Such implementation ensures a significant speedup for queries where the limit is lower than the actual intersection cardinality.
 
-@return
-
-@integer-reply: the number of elements in the resulting intersection.
-
 @examples
 
 ```cli

--- a/commands/sinterstore.md
+++ b/commands/sinterstore.md
@@ -3,10 +3,6 @@ it is stored in `destination`.
 
 If `destination` already exists, it is overwritten.
 
-@return
-
-@integer-reply: the number of elements in the resulting set.
-
 @examples
 
 ```cli

--- a/commands/sismember.md
+++ b/commands/sismember.md
@@ -1,12 +1,5 @@
 Returns if `member` is a member of the set stored at `key`.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the element is a member of the set.
-* `0` if the element is not a member of the set, or if `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/slaveof.md
+++ b/commands/slaveof.md
@@ -16,7 +16,3 @@ So, if the old master stops working, it is possible to turn the replica into a
 master and set the application to use this new master in read/write.
 Later when the other Redis server is fixed, it can be reconfigured to work as a
 replica.
-
-@return
-
-@simple-string-reply

--- a/commands/slowlog-get.md
+++ b/commands/slowlog-get.md
@@ -20,7 +20,3 @@ Each entry from the slow log is comprised of the following six values:
 The entry's unique ID can be used in order to avoid processing slow log entries multiple times (for instance you may have a script sending you an email alert for every new slow log entry).
 The ID is never reset in the course of the Redis server execution, only a server
 restart will reset it.
-
-@return
-
-@array-reply: a list of slow log entries.

--- a/commands/slowlog-help.md
+++ b/commands/slowlog-help.md
@@ -1,5 +1,1 @@
 The `SLOWLOG HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/slowlog-len.md
+++ b/commands/slowlog-len.md
@@ -4,9 +4,3 @@ A new entry is added to the slow log whenever a command exceeds the execution ti
 The maximum number of entries in the slow log is governed by the `slowlog-max-len` configuration directive.
 Once the slog log reaches its maximal size, the oldest entry is removed whenever a new entry is created.
 The slow log can be cleared with the `SLOWLOG RESET` command.
-
-@return
-
-@integer-reply
-
-The number of entries in the slow log.

--- a/commands/slowlog-reset.md
+++ b/commands/slowlog-reset.md
@@ -1,7 +1,3 @@
 This command resets the slow log, clearing all entries in it.
 
 Once deleted the information is lost forever.
-
-@return
-
-@simple-string-reply: `OK`

--- a/commands/smembers.md
+++ b/commands/smembers.md
@@ -2,10 +2,6 @@ Returns all the members of the set value stored at `key`.
 
 This has the same effect as running `SINTER` with one argument `key`.
 
-@return
-
-@array-reply: all elements of the set.
-
 @examples
 
 ```cli

--- a/commands/smismember.md
+++ b/commands/smismember.md
@@ -2,11 +2,6 @@ Returns whether each `member` is a member of the set stored at `key`.
 
 For every `member`, `1` is returned if the value is a member of the set, or `0` if the element is not a member of the set or if `key` does not exist.
 
-@return
-
-@array-reply: list representing the membership of the given elements, in the same
-order as they are requested.
-
 @examples
 
 ```cli

--- a/commands/smove.md
+++ b/commands/smove.md
@@ -12,13 +12,6 @@ removed from the source set.
 
 An error is returned if `source` or `destination` does not hold a set value.
 
-@return
-
-@integer-reply, specifically:
-
-* `1` if the element is moved.
-* `0` if the element is not a member of `source` and no operation was performed.
-
 @examples
 
 ```cli

--- a/commands/sort.md
+++ b/commands/sort.md
@@ -147,8 +147,3 @@ SORT mylist BY weight_*->fieldname GET object_*->fieldname
 The string `->` is used to separate the key name from the hash field name.
 The key is substituted as documented above, and the hash stored at the resulting
 key is accessed to retrieve the specified hash field.
-
-@return
-
-@array-reply: without passing the `store` option the command returns a list of sorted elements.
-@integer-reply: when the `store` option is specified the command returns the number of sorted elements in the destination list.

--- a/commands/sort_ro.md
+++ b/commands/sort_ro.md
@@ -11,7 +11,3 @@ See original `SORT` for more details.
 ```
 SORT_RO mylist BY weight_*->fieldname GET object_*->fieldname
 ```
-
-@return
-
-@array-reply: a list of sorted elements.

--- a/commands/spop.md
+++ b/commands/spop.md
@@ -6,16 +6,6 @@ By default, the command pops a single member from the set. When provided with
 the optional `count` argument, the reply will consist of up to `count` members,
 depending on the set's cardinality.
 
-@return
-
-When called without the `count` argument:
-
-@bulk-string-reply: the removed member, or `nil` when `key` does not exist.
-
-When called with the `count` argument:
-
-@array-reply: the removed members, or an empty array when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/spublish.md
+++ b/commands/spublish.md
@@ -6,11 +6,6 @@ The cluster makes sure that published shard messages are forwarded to all the no
 
 For more information about sharded pubsub, see [Sharded Pubsub](/topics/pubsub#sharded-pubsub).
 
-@return
-
-@integer-reply: the number of clients that received the message.
-Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count.
-
 @examples
 
 For example the following command publish to channel `orders` with a subscriber already waiting for message(s).

--- a/commands/srandmember.md
+++ b/commands/srandmember.md
@@ -6,12 +6,6 @@ The array's length is either `count` or the set's cardinality (`SCARD`), whichev
 If called with a negative `count`, the behavior changes and the command is allowed to return the **same element multiple times**.
 In this case, the number of returned elements is the absolute value of the specified `count`.
 
-@return
-
-@bulk-string-reply: without the additional `count` argument, the command returns a Bulk Reply with the randomly selected element, or `nil` when `key` does not exist.
-
-@array-reply: when the additional `count` argument is passed, the command returns an array of elements, or an empty array when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/srem.md
+++ b/commands/srem.md
@@ -5,11 +5,6 @@ If `key` does not exist, it is treated as an empty set and this command returns
 
 An error is returned when the value stored at `key` is not a set.
 
-@return
-
-@integer-reply: the number of members that were removed from the set, not
-including non existing members.
-
 @examples
 
 ```cli

--- a/commands/ssubscribe.md
+++ b/commands/ssubscribe.md
@@ -7,12 +7,6 @@ A client can subscribe to channels across different slots over separate `SSUBSCR
 
 For more information about sharded Pub/Sub, see [Sharded Pub/Sub](/topics/pubsub#sharded-pubsub).
 
-@return
-
-When successful, this command doesn't return anything.
-Instead, for each shard channel, one message with the first element being the string "ssubscribe" is pushed as a confirmation that the command succeeded.
-Note that this command can also return a -MOVED redirect.
-
 @examples
 
 ```

--- a/commands/strlen.md
+++ b/commands/strlen.md
@@ -1,11 +1,6 @@
 Returns the length of the string value stored at `key`.
 An error is returned when `key` holds a non-string value.
 
-@return
-
-@integer-reply: the length of the string at `key`, or `0` when `key` does not
-exist.
-
 @examples
 
 ```cli

--- a/commands/subscribe.md
+++ b/commands/subscribe.md
@@ -7,11 +7,6 @@ However, if RESP3 is used (see `HELLO`) it is possible for a client to issue any
 
 For more information, see [Pub/sub](/docs/interact/pubsub/).
 
-@return
-
-When successful, this command doesn't return anything.
-Instead, for each channel, one message with the first element being the string "subscribe" is pushed as a confirmation that the command succeeded.
-
 ## Behavior change history
 
 *   `>= 6.2.0`: `RESET` can be called to exit subscribed state.

--- a/commands/substr.md
+++ b/commands/substr.md
@@ -7,10 +7,6 @@ So -1 means the last character, -2 the penultimate and so forth.
 The function handles out of range requests by limiting the resulting range to
 the actual length of the string.
 
-@return
-
-@bulk-string-reply
-
 @examples
 
 ```cli

--- a/commands/sunion.md
+++ b/commands/sunion.md
@@ -11,10 +11,6 @@ SUNION key1 key2 key3 = {a,b,c,d,e}
 
 Keys that do not exist are considered to be empty sets.
 
-@return
-
-@array-reply: list with members of the resulting set.
-
 @examples
 
 ```cli

--- a/commands/sunionstore.md
+++ b/commands/sunionstore.md
@@ -3,10 +3,6 @@ it is stored in `destination`.
 
 If `destination` already exists, it is overwritten.
 
-@return
-
-@integer-reply: the number of elements in the resulting set.
-
 @examples
 
 ```cli

--- a/commands/sunsubscribe.md
+++ b/commands/sunsubscribe.md
@@ -6,8 +6,3 @@ In this case a message for every unsubscribed shard channel will be sent to the 
 Note: The global channels and shard channels needs to be unsubscribed from separately.
 
 For more information about sharded Pub/Sub, see [Sharded Pub/Sub](/topics/pubsub#sharded-pubsub).
-
-@return
-
-When successful, this command doesn't return anything.
-Instead, for each shard channel, one message with the first element being the string "sunsubscribe" is pushed as a confirmation that the command succeeded.

--- a/commands/swapdb.md
+++ b/commands/swapdb.md
@@ -6,10 +6,6 @@ the other way around. Example:
 
 This will swap database 0 with database 1. All the clients connected with database 0 will immediately see the new data, exactly like all the clients connected with database 1 will see the data that was formerly of database 0.
 
-@return
-
-@simple-string-reply: `OK` if `SWAPDB` was executed correctly.
-
 @examples
 
 ```

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -8,7 +8,3 @@ For more information about replication in Redis please check the
 [replication page][tr].
 
 [tr]: /topics/replication
-
-@return
-
-**Non standard return value**, a bulk transfer of the data followed by `PING` and write requests from the master.

--- a/commands/time.md
+++ b/commands/time.md
@@ -3,15 +3,6 @@ timestamp and the amount of microseconds already elapsed in the current second.
 Basically the interface is very similar to the one of the `gettimeofday` system
 call.
 
-@return
-
-@array-reply, specifically:
-
-A multi bulk reply containing two elements:
-
-* unix time in seconds.
-* microseconds.
-
 @examples
 
 ```cli

--- a/commands/touch.md
+++ b/commands/touch.md
@@ -1,10 +1,6 @@
 Alters the last access time of a key(s).
 A key is ignored if it does not exist.
 
-@return
-
-@integer-reply: The number of keys that were touched.
-
 @examples
 
 ```cli

--- a/commands/ttl.md
+++ b/commands/ttl.md
@@ -11,10 +11,6 @@ Starting with Redis 2.8 the return value in case of error changed:
 
 See also the `PTTL` command that returns the same information with milliseconds resolution (Only available in Redis 2.6 or greater).
 
-@return
-
-@integer-reply: TTL in seconds, or a negative value in order to signal an error (see the description above).
-
 @examples
 
 ```cli

--- a/commands/type.md
+++ b/commands/type.md
@@ -2,10 +2,6 @@ Returns the string representation of the type of the value stored at `key`.
 The different types that can be returned are: `string`, `list`, `set`, `zset`,
 `hash` and `stream`.
 
-@return
-
-@simple-string-reply: type of `key`, or `none` when `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/unlink.md
+++ b/commands/unlink.md
@@ -5,10 +5,6 @@ blocking, while `DEL` is. This is where the command name comes from: the
 command just **unlinks** the keys from the keyspace. The actual removal
 will happen later asynchronously.
 
-@return
-
-@integer-reply: The number of keys that were unlinked.
-
 @examples
 
 ```cli

--- a/commands/unsubscribe.md
+++ b/commands/unsubscribe.md
@@ -5,8 +5,3 @@ When no channels are specified, the client is unsubscribed from all the
 previously subscribed channels.
 In this case, a message for every unsubscribed channel will be sent to the
 client.
-
-@return
-
-When successful, this command doesn't return anything.
-Instead, for each channel, one message with the first element being the string "unsubscribe" is pushed as a confirmation that the command succeeded.

--- a/commands/unwatch.md
+++ b/commands/unwatch.md
@@ -3,7 +3,3 @@ Flushes all the previously watched keys for a [transaction][tt].
 [tt]: /topics/transactions
 
 If you call `EXEC` or `DISCARD`, there's no need to manually call `UNWATCH`.
-
-@return
-
-@simple-string-reply: always `OK`.

--- a/commands/wait.md
+++ b/commands/wait.md
@@ -37,10 +37,6 @@ write command was executed in the context of a given client. When `WAIT` is
 called Redis checks if the specified number of replicas already acknowledged
 this offset or a greater one.
 
-@return
-
-@integer-reply: The command returns the number of replicas reached by all the writes performed in the context of the current connection.
-
 @examples
 
 ```

--- a/commands/waitaof.md
+++ b/commands/waitaof.md
@@ -35,10 +35,6 @@ In addition, Redis replicas asynchronously ping their master with two replicatio
 Redis remembers, for each client, the replication offset of the produced replication stream when the last write command was executed in the context of that client.
 When `WAITAOF` is called, Redis checks if the local Redis and/or the specified number of replicas have confirmed fsyncing this offset or a greater one to their AOF.
 
-@return
-
-@array-reply: The command returns an array of two integers: The first is the number of local Redises (0 or 1) that have fsynced to AOF  all writes performed in the context of the current connection; The second is the number of replicas that have acknowledged doing the same.
-
 @examples
 
 ```

--- a/commands/watch.md
+++ b/commands/watch.md
@@ -2,7 +2,3 @@ Marks the given keys to be watched for conditional execution of a
 [transaction][tt].
 
 [tt]: /topics/transactions
-
-@return
-
-@simple-string-reply: always `OK`.

--- a/commands/xack.md
+++ b/commands/xack.md
@@ -14,15 +14,6 @@ so that such message does not get processed again, and as a side effect,
 the PEL entry about this message is also purged, releasing memory from the
 Redis server.
 
-@return
-
-@integer-reply, specifically:
-
-The command returns the number of messages successfully acknowledged.
-Certain message IDs may no longer be part of the PEL (for example because
-they have already been acknowledged), and XACK will not count them as
-successfully acknowledged.
-
 @examples
 
 ```

--- a/commands/xadd.md
+++ b/commands/xadd.md
@@ -72,17 +72,6 @@ Will add a new entry but will also evict old entries so that the stream will con
 For further information about Redis streams please check our
 [introduction to Redis Streams document](/topics/streams-intro).
 
-@return
-
-@bulk-string-reply, specifically:
-
-The command returns the ID of the added entry. The ID is the one auto-generated
-if `*` is passed as ID argument, otherwise the command just returns the same ID
-specified by the user during insertion.
-
-The command returns a @nil-reply when used with the `NOMKSTREAM` option and the
-key doesn't exist.
-
 @examples
 
 ```cli

--- a/commands/xautoclaim.md
+++ b/commands/xautoclaim.md
@@ -25,16 +25,6 @@ These message IDs are returned to the caller as a part of `XAUTOCLAIM`s reply.
 Lastly, claiming a message with `XAUTOCLAIM` also increments the attempted deliveries count for that message, unless the `JUSTID` option has been specified (which only delivers the message ID, not the message itself).
 Messages that cannot be processed for some reason - for example, because consumers systematically crash when processing them - will exhibit high attempted delivery counts that can be detected by monitoring.
 
-@return
-
-@array-reply, specifically:
-
-An array with three elements:
-
-1. A stream ID to be used as the `<start>` argument for the next call to `XAUTOCLAIM`.
-2. An array containing all the successfully claimed messages in the same format as `XRANGE`.
-3. An array containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found.
-
 @examples
 
 ```

--- a/commands/xclaim.md
+++ b/commands/xclaim.md
@@ -35,14 +35,6 @@ useful to normal users:
 4. `FORCE`: Creates the pending message entry in the PEL even if certain specified IDs are not already in the PEL assigned to a different client. However the message must be exist in the stream, otherwise the IDs of non existing messages are ignored.
 5. `JUSTID`: Return just an array of IDs of messages successfully claimed, without returning the actual message. Using this option means the retry counter is not incremented.
 
-@return
-
-@array-reply, specifically:
-
-The command returns all the messages successfully claimed, in the same format
-as `XRANGE`. However if the `JUSTID` option was specified, only the message
-IDs are reported, without including the actual message.
-
 @examples
 
 ```

--- a/commands/xdel.md
+++ b/commands/xdel.md
@@ -26,10 +26,6 @@ collection in case a given macro-node reaches a given amount of deleted
 entries. Currently with the usage we anticipate for this data structure, it is
 not a good idea to add such complexity.
 
-@return
-
-@integer-reply: the number of entries actually deleted.
-
 @examples
 
 ```

--- a/commands/xgroup-create.md
+++ b/commands/xgroup-create.md
@@ -19,7 +19,3 @@ To enable consumer group lag tracking, specify the optional `entries_read` named
 An arbitrary ID is any ID that isn't the ID of the stream's first entry, last entry, or zero ("0-0") ID.
 Use it to find out how many entries are between the arbitrary ID (excluding it) and the stream's last entry.
 Set the `entries_read` the stream's `entries_added` subtracted by the number of entries.
-
-@return
-
-@simple-string-reply: `OK` on success.

--- a/commands/xgroup-createconsumer.md
+++ b/commands/xgroup-createconsumer.md
@@ -2,7 +2,3 @@ Create a consumer named `<consumername>` in the consumer group `<groupname>` of 
 
 Consumers are also created automatically whenever an operation, such as `XREADGROUP`, references a consumer that doesn't exist.
 This is valid for `XREADGROUP` only when there is data in the stream.
-
-@return
-
-@integer-reply: the number of created consumers (0 or 1)

--- a/commands/xgroup-delconsumer.md
+++ b/commands/xgroup-delconsumer.md
@@ -4,7 +4,3 @@ Sometimes it may be useful to remove old consumers since they are no longer used
 
 Note, however, that any pending messages that the consumer had will become unclaimable after it was deleted.
 It is strongly recommended, therefore, that any pending messages are claimed or acknowledged prior to deleting the consumer from the group.
-
-@return
-
-@integer-reply: the number of pending messages that the consumer had before it was deleted

--- a/commands/xgroup-destroy.md
+++ b/commands/xgroup-destroy.md
@@ -1,7 +1,3 @@
 The `XGROUP DESTROY` command completely destroys a consumer group.
 
 The consumer group will be destroyed even if there are active consumers, and pending messages, so make sure to call this command only when really needed.
-
-@return
-
-@integer-reply: the number of destroyed consumer groups (0 or 1)

--- a/commands/xgroup-help.md
+++ b/commands/xgroup-help.md
@@ -1,5 +1,1 @@
 The `XGROUP HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/xgroup-setid.md
+++ b/commands/xgroup-setid.md
@@ -10,7 +10,3 @@ The optional `entries_read` argument can be specified to enable consumer group l
 An arbitrary ID is any ID that isn't the ID of the stream's first entry, its last entry or the zero ("0-0") ID.
 This can be useful you know exactly how many entries are between the arbitrary ID (excluding it) and the stream's last entry.
 In such cases, the `entries_read` can be set to the stream's `entries_added` subtracted with the number of entries.
-
-@return
-
-@simple-string-reply: `OK` on success.

--- a/commands/xinfo-consumers.md
+++ b/commands/xinfo-consumers.md
@@ -7,10 +7,6 @@ The following information is provided for each consumer in the group:
 * **idle**: the number of milliseconds that have passed since the consumer's last attempted interaction (Examples: `XREADGROUP`, `XCLAIM`, `XAUTOCLAIM`)
 * **inactive**: the number of milliseconds that have passed since the consumer's last successful interaction (Examples: `XREADGROUP` that actually read some entries into the PEL, `XCLAIM`/`XAUTOCLAIM` that actually claimed some entries)
 
-@return
-
-@array-reply: a list of consumers.
-
 @examples
 
 ```

--- a/commands/xinfo-groups.md
+++ b/commands/xinfo-groups.md
@@ -39,10 +39,6 @@ However, the lag is only temporarily unavailable.
 It is restored automatically during regular operation as consumers keep processing messages.
 Once the consumer group delivers the last message in the stream to its members, it will be set with the correct logical read counter, and tracking its lag can be resumed.
 
-@return
-
-@array-reply: a list of consumer groups.
-
 @examples
 
 ```

--- a/commands/xinfo-help.md
+++ b/commands/xinfo-help.md
@@ -1,5 +1,1 @@
 The `XINFO HELP` command returns a helpful text describing the different subcommands.
-
-@return
-
-@array-reply: a list of subcommands and their descriptions

--- a/commands/xinfo-stream.md
+++ b/commands/xinfo-stream.md
@@ -19,10 +19,6 @@ Furthermore, **groups** is also an array, and for each of the consumer groups it
 The `COUNT` option can be used to limit the number of stream and PEL entries that are returned (The first `<count>` entries are returned).
 The default `COUNT` is 10 and a `COUNT` of 0 means that all entries will be returned (execution time may be long if the stream has a lot of entries).
 
-@return
-
-@array-reply: a list of informational bits
-
 @examples
 
 Default reply:

--- a/commands/xlen.md
+++ b/commands/xlen.md
@@ -8,10 +8,6 @@ Streams are not auto-deleted once they have no entries inside (for instance
 after an `XDEL` call), because the stream may have consumer groups
 associated with it.
 
-@return
-
-@integer-reply: the number of entries of the stream at `key`.
-
 @examples
 
 ```cli

--- a/commands/xpending.md
+++ b/commands/xpending.md
@@ -127,11 +127,3 @@ The `XPENDING` command allows iterating over the pending entries just like
 prefixing the ID of the last-read pending entry with the `(` character that
 denotes an open (exclusive) range, and proving it to the subsequent call to the
 command.
-
-@return
-
-@array-reply, specifically:
-
-The command returns data in different format depending on the way it is
-called, as previously explained in this page. However the reply is always
-an array of items.

--- a/commands/xrange.md
+++ b/commands/xrange.md
@@ -200,15 +200,6 @@ of XRANGE:
 For further information about Redis streams please check our
 [introduction to Redis Streams document](/topics/streams-intro).
 
-@return
-
-@array-reply, specifically:
-
-The command returns the entries with IDs matching the specified range.
-The returned entries are complete, that means that the ID and all the fields
-they are composed are returned. Moreover, the entries are returned with
-their fields and values in the exact same order as `XADD` added them.
-
 @examples
 
 ```cli

--- a/commands/xread.md
+++ b/commands/xread.md
@@ -197,19 +197,6 @@ are not removed from the stream when clients are served, so every
 client waiting will be served as soon as an `XADD` command provides
 data to the stream.
 
-@return
-
-@array-reply, specifically:
-
-The command returns an array of results: each element of the returned
-array is an array composed of a two element containing the key name and
-the entries reported for that key. The entries reported are full stream
-entries, having IDs and the list of all the fields and values. Field and
-values are guaranteed to be reported in the same order they were added
-by `XADD`.
-
-When **BLOCK** is used, on timeout a null reply is returned.
-
 Reading the [Redis Streams introduction](/topics/streams-intro) is highly
 suggested in order to understand more about the streams overall behavior
 and semantics.

--- a/commands/xreadgroup.md
+++ b/commands/xreadgroup.md
@@ -129,19 +129,6 @@ OK
          2) (nil)
 ```
 
-@return
-
-@array-reply, specifically:
-
-The command returns an array of results: each element of the returned
-array is an array composed of a two element containing the key name and
-the entries reported for that key. The entries reported are full stream
-entries, having IDs and the list of all the fields and values. Field and
-values are guaranteed to be reported in the same order they were added
-by `XADD`.
-
-When **BLOCK** is used, on timeout a null reply is returned.
-
 Reading the [Redis Streams introduction](/topics/streams-intro) is highly
 suggested in order to understand more about the streams overall behavior
 and semantics.

--- a/commands/xrevrange.md
+++ b/commands/xrevrange.md
@@ -14,16 +14,6 @@ enough to send:
 
     XREVRANGE somestream + - COUNT 1
 
-@return
-
-@array-reply, specifically:
-
-The command returns the entries with IDs matching the specified range,
-from the higher ID to the lower ID matching.
-The returned entries are complete, that means that the ID and all the fields
-they are composed are returned. Moreover the entries are returned with
-their fields and values in the exact same order as `XADD` added them.
-
 @examples
 
 ```cli

--- a/commands/xtrim.md
+++ b/commands/xtrim.md
@@ -44,10 +44,6 @@ When used, it specifies the maximal `count` of entries that will be evicted.
 When `LIMIT` and `count` aren't specified, the default value of 100 * the number of entries in a macro node will be implicitly used as the `count`.
 Specifying the value 0 as `count` disables the limiting mechanism entirely.
 
-@return
-
-@integer-reply: The number of entries deleted from the stream.
-
 @examples
 
 ```cli

--- a/commands/zadd.md
+++ b/commands/zadd.md
@@ -58,17 +58,6 @@ The lexicographic ordering used is binary, it compares strings as array of bytes
 
 If the user inserts all the elements in a sorted set with the same score (for example 0), all the elements of the sorted set are sorted lexicographically, and range queries on elements are possible using the command `ZRANGEBYLEX` (Note: it is also possible to query sorted sets by range of scores using `ZRANGEBYSCORE`).
 
-@return
-
-@integer-reply, specifically:
-
-* When used without optional arguments, the number of elements added to the sorted set (excluding score updates).
-* If the `CH` option is specified, the number of elements that were changed (added or updated).
-
-If the `INCR` option is specified, the return value will be @bulk-string-reply:
-
-* The new score of `member` (a double precision floating point number) represented as string, or `nil` if the operation was aborted (when called with either the `XX` or the `NX` option).
-
 @examples
 
 ```cli

--- a/commands/zcard.md
+++ b/commands/zcard.md
@@ -1,11 +1,6 @@
 Returns the sorted set cardinality (number of elements) of the sorted set stored
 at `key`.
 
-@return
-
-@integer-reply: the cardinality (number of elements) of the sorted set, or `0`
-if `key` does not exist.
-
 @examples
 
 ```cli

--- a/commands/zcount.md
+++ b/commands/zcount.md
@@ -6,10 +6,6 @@ The `min` and `max` arguments have the same semantic as described for
 
 Note: the command has a complexity of just O(log(N)) because it uses elements ranks (see `ZRANK`) to get an idea of the range. Because of this there is no need to do a work proportional to the size of the range.
 
-@return
-
-@integer-reply: the number of elements in the specified score range.
-
 @examples
 
 ```cli

--- a/commands/zdiff.md
+++ b/commands/zdiff.md
@@ -1,11 +1,6 @@
 This command is similar to `ZDIFFSTORE`, but instead of storing the resulting
 sorted set, it is returned to the client.
 
-@return
-
-@array-reply: the result of the difference (optionally with their scores, in case
-the `WITHSCORES` option is given).
-
 @examples
 
 ```cli

--- a/commands/zdiffstore.md
+++ b/commands/zdiffstore.md
@@ -6,11 +6,6 @@ Keys that do not exist are considered to be empty sets.
 
 If `destination` already exists, it is overwritten.
 
-@return
-
-@integer-reply: the number of elements in the resulting sorted set at
-`destination`.
-
 @examples
 
 ```cli

--- a/commands/zincrby.md
+++ b/commands/zincrby.md
@@ -11,11 +11,6 @@ The `score` value should be the string representation of a numeric value, and
 accepts double precision floating point numbers.
 It is possible to provide a negative value to decrement the score.
 
-@return
-
-@bulk-string-reply: the new score of `member` (a double precision floating point
-number), represented as string.
-
 @examples
 
 ```cli

--- a/commands/zinter.md
+++ b/commands/zinter.md
@@ -3,11 +3,6 @@ sorted set, it is returned to the client.
 
 For a description of the `WEIGHTS` and `AGGREGATE` options, see `ZUNIONSTORE`.
 
-@return
-
-@array-reply: the result of intersection (optionally with their scores, in case 
-the `WITHSCORES` option is given).
-
 @examples
 
 ```cli

--- a/commands/zintercard.md
+++ b/commands/zintercard.md
@@ -7,10 +7,6 @@ By default, the command calculates the cardinality of the intersection of all gi
 When provided with the optional `LIMIT` argument (which defaults to 0 and means unlimited), if the intersection cardinality reaches limit partway through the computation, the algorithm will exit and yield limit as the cardinality.
 Such implementation ensures a significant speedup for queries where the limit is lower than the actual intersection cardinality.
 
-@return
-
-@integer-reply: the number of elements in the resulting intersection.
-
 @examples
 
 ```cli

--- a/commands/zinterstore.md
+++ b/commands/zinterstore.md
@@ -13,11 +13,6 @@ For a description of the `WEIGHTS` and `AGGREGATE` options, see `ZUNIONSTORE`.
 
 If `destination` already exists, it is overwritten.
 
-@return
-
-@integer-reply: the number of elements in the resulting sorted set at
-`destination`.
-
 @examples
 
 ```cli

--- a/commands/zlexcount.md
+++ b/commands/zlexcount.md
@@ -5,10 +5,6 @@ The `min` and `max` arguments have the same meaning as described for
 
 Note: the command has a complexity of just O(log(N)) because it uses elements ranks (see `ZRANK`) to get an idea of the range. Because of this there is no need to do a work proportional to the size of the range.
 
-@return
-
-@integer-reply: the number of elements in the specified score range.
-
 @examples
 
 ```cli

--- a/commands/zmpop.md
+++ b/commands/zmpop.md
@@ -12,13 +12,6 @@ The optional `COUNT` can be used to specify the number of elements to pop, and i
 
 The number of popped elements is the minimum from the sorted set's cardinality and `COUNT`'s value.
 
-@return
-
-@array-reply: specifically:
-
-* A `nil` when no element could be popped.
-* A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score.
-
 @examples
 
 ```cli

--- a/commands/zmscore.md
+++ b/commands/zmscore.md
@@ -2,11 +2,6 @@ Returns the scores associated with the specified `members` in the sorted set sto
 
 For every `member` that does not exist in the sorted set, a `nil` value is returned.
 
-@return
-
-@array-reply: list of scores or `nil` associated with the specified `member` values (a double precision floating point number),
-represented as strings.
-
 @examples
 
 ```cli

--- a/commands/zpopmax.md
+++ b/commands/zpopmax.md
@@ -6,10 +6,6 @@ value that is higher than the sorted set's cardinality will not produce an
 error. When returning multiple elements, the one with the highest score will
 be the first, followed by the elements with lower scores.
 
-@return
-
-@array-reply: list of popped elements and scores.
-
 @examples
 
 ```cli

--- a/commands/zpopmin.md
+++ b/commands/zpopmin.md
@@ -6,10 +6,6 @@ value that is higher than the sorted set's cardinality will not produce an
 error. When returning multiple elements, the one with the lowest score will
 be the first, followed by the elements with greater scores.
 
-@return
-
-@array-reply: list of popped elements and scores.
-
 @examples
 
 ```cli

--- a/commands/zrandmember.md
+++ b/commands/zrandmember.md
@@ -8,13 +8,6 @@ In this case, the number of returned elements is the absolute value of the speci
 
 The optional `WITHSCORES` modifier changes the reply so it includes the respective scores of the randomly selected elements from the sorted set.
 
-@return
-
-@bulk-string-reply: without the additional `count` argument, the command returns a Bulk Reply with the randomly selected element, or `nil` when `key` does not exist.
-
-@array-reply: when the additional `count` argument is passed, the command returns an array of elements, or an empty array when `key` does not exist.
-If the `WITHSCORES` modifier is used, the reply is a list elements and their scores from the sorted set.
-
 @examples
 
 ```cli

--- a/commands/zrange.md
+++ b/commands/zrange.md
@@ -100,11 +100,6 @@ Because of the first *normalized* part in every element (before the colon charac
 
 The binary nature of the comparison allows to use sorted sets as a general purpose index, for example, the first part of the element can be a 64-bit big-endian number. Since big-endian numbers have the most significant bytes in the initial positions, the binary comparison will match the numerical comparison of the numbers. This can be used in order to implement range queries on 64-bit values. As in the example below, after the first 8 bytes, we can store the value of the element we are indexing.
 
-@return
-
-@array-reply: list of elements in the specified range (optionally with
-their scores, in case the `WITHSCORES` option is given).
-
 @examples
 
 ```cli

--- a/commands/zrangebylex.md
+++ b/commands/zrangebylex.md
@@ -47,10 +47,6 @@ comparison of the numbers. This can be used in order to implement range
 queries on 64 bit values. As in the example below, after the first 8 bytes
 we can store the value of the element we are actually indexing.
 
-@return
-
-@array-reply: list of elements in the specified score range.
-
 @examples
 
 ```cli

--- a/commands/zrangebyscore.md
+++ b/commands/zrangebyscore.md
@@ -40,11 +40,6 @@ ZRANGEBYSCORE zset (5 (10
 
 Will return all the elements with `5 < score < 10` (5 and 10 excluded).
 
-@return
-
-@array-reply: list of elements in the specified score range (optionally
-with their scores).
-
 @examples
 
 ```cli

--- a/commands/zrangestore.md
+++ b/commands/zrangestore.md
@@ -1,9 +1,5 @@
 This command is like `ZRANGE`, but stores the result in the `<dst>` destination key.
 
-@return
-
-@integer-reply: the number of elements in the resulting sorted set.
-
 @examples
 
 ```cli

--- a/commands/zrank.md
+++ b/commands/zrank.md
@@ -8,17 +8,6 @@ The optional `WITHSCORE` argument supplements the command's reply with the score
 Use `ZREVRANK` to get the rank of an element with the scores ordered from high
 to low.
 
-@return
-
-* If `member` exists in the sorted set:
-  * using `WITHSCORE`, @array-reply: an array containing the rank and score of `member`.
-  * without using `WITHSCORE`, @integer-reply: the rank of `member`.
-* If `member` does not exist in the sorted set or `key` does not exist:
-  * using `WITHSCORE`, @array-reply: `nil`.
-  * without using `WITHSCORE`, @bulk-string-reply: `nil`.
-  
-Note that in RESP3 null and nullarray are the same, but in RESP2 they are not.
-
 @examples
 
 ```cli

--- a/commands/zrem.md
+++ b/commands/zrem.md
@@ -3,13 +3,6 @@ Non existing members are ignored.
 
 An error is returned when `key` exists and does not hold a sorted set.
 
-@return
-
-@integer-reply, specifically:
-
-* The number of members removed from the sorted set, not including non existing
-  members.
-
 @examples
 
 ```cli

--- a/commands/zremrangebylex.md
+++ b/commands/zremrangebylex.md
@@ -2,10 +2,6 @@ When all the elements in a sorted set are inserted with the same score, in order
 
 The meaning of `min` and `max` are the same of the `ZRANGEBYLEX` command. Similarly, this command actually removes the same elements that `ZRANGEBYLEX` would return if called with the same `min` and `max` arguments.
 
-@return
-
-@integer-reply: the number of elements removed.
-
 @examples
 
 ```cli

--- a/commands/zremrangebyrank.md
+++ b/commands/zremrangebyrank.md
@@ -7,10 +7,6 @@ the element with the highest score.
 For example: `-1` is the element with the highest score, `-2` the element with
 the second highest score and so forth.
 
-@return
-
-@integer-reply: the number of elements removed.
-
 @examples
 
 ```cli

--- a/commands/zremrangebyscore.md
+++ b/commands/zremrangebyscore.md
@@ -1,10 +1,6 @@
 Removes all elements in the sorted set stored at `key` with a score between
 `min` and `max` (inclusive).
 
-@return
-
-@integer-reply: the number of elements removed.
-
 @examples
 
 ```cli

--- a/commands/zrevrange.md
+++ b/commands/zrevrange.md
@@ -4,11 +4,6 @@ Descending lexicographical order is used for elements with equal score.
 
 Apart from the reversed ordering, `ZREVRANGE` is similar to `ZRANGE`.
 
-@return
-
-@array-reply: list of elements in the specified range (optionally with
-their scores).
-
 @examples
 
 ```cli

--- a/commands/zrevrangebylex.md
+++ b/commands/zrevrangebylex.md
@@ -2,10 +2,6 @@ When all the elements in a sorted set are inserted with the same score, in order
 
 Apart from the reversed ordering, `ZREVRANGEBYLEX` is similar to `ZRANGEBYLEX`.
 
-@return
-
-@array-reply: list of elements in the specified score range.
-
 @examples
 
 ```cli

--- a/commands/zrevrangebyscore.md
+++ b/commands/zrevrangebyscore.md
@@ -9,11 +9,6 @@ order.
 Apart from the reversed ordering, `ZREVRANGEBYSCORE` is similar to
 `ZRANGEBYSCORE`.
 
-@return
-
-@array-reply: list of elements in the specified score range (optionally
-with their scores).
-
 @examples
 
 ```cli

--- a/commands/zrevrank.md
+++ b/commands/zrevrank.md
@@ -8,17 +8,6 @@ The optional `WITHSCORE` argument supplements the command's reply with the score
 Use `ZRANK` to get the rank of an element with the scores ordered from low to
 high.
 
-@return
-
-* If `member` exists in the sorted set:
-  * using `WITHSCORE`, @array-reply: an array containing the rank and score of `member`.
-  * without using `WITHSCORE`, @integer-reply: the rank of `member`.
-* If `member` does not exist in the sorted set or `key` does not exist:
-  * using `WITHSCORE`, @array-reply: `nil`.
-  * without using `WITHSCORE`, @bulk-string-reply: `nil`.
-  
-Note that in RESP3 null and nullarray are the same, but in RESP2 they are not.
-
 @examples
 
 ```cli

--- a/commands/zscore.md
+++ b/commands/zscore.md
@@ -3,11 +3,6 @@ Returns the score of `member` in the sorted set at `key`.
 If `member` does not exist in the sorted set, or `key` does not exist, `nil` is
 returned.
 
-@return
-
-@bulk-string-reply: the score of `member` (a double precision floating point number),
-represented as string.
-
 @examples
 
 ```cli

--- a/commands/zunion.md
+++ b/commands/zunion.md
@@ -3,11 +3,6 @@ sorted set, it is returned to the client.
 
 For a description of the `WEIGHTS` and `AGGREGATE` options, see `ZUNIONSTORE`.
 
-@return
-
-@array-reply: the result of union (optionally with their scores, in case 
-the `WITHSCORES` option is given).
-
 @examples
 
 ```cli

--- a/commands/zunionstore.md
+++ b/commands/zunionstore.md
@@ -21,11 +21,6 @@ the minimum or maximum score of an element across the inputs where it exists.
 
 If `destination` already exists, it is overwritten.
 
-@return
-
-@integer-reply: the number of elements in the resulting sorted set at
-`destination`.
-
 @examples
 
 ```cli

--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -1,0 +1,1318 @@
+{
+  "ACL": [],
+  "ACL CAT": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL categories or commands in a given category.",
+    "* [Simple error reply](/docs/reference/protocol-spec#simple-errors): the command returns an error if an invalid category name is given."
+  ],
+  "ACL DELUSER": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
+  ],
+  "ACL DRYRUN": [
+    "Any of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): an error describing why the user can't execute the command."
+  ],
+  "ACL GENPASS": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4."
+  ],
+  "ACL GETUSER": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of ACL rule definitions for the user.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if user does not exist."
+  ],
+  "ACL HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+  ],
+  "ACL LIST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements."
+  ],
+  "ACL LOG": [
+    "When called to show security events:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL security events.",
+    "When called with `RESET`:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the security log was cleared."
+  ],
+  "ACL SAVE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`.",
+    "The command may fail with an error for several reasons: if the file cannot be written or if the server is not configured to use an external ACL file."
+  ],
+  "ACL SETUSER": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`.",
+    "If the rules contain errors, the error is returned."
+  ],
+  "ACL USERS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): list of existing ACL users."
+  ],
+  "ACL WHOAMI": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the username of the current connection."
+  ],
+  "ACL-LOAD": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
+    "",
+    "The command may fail with an error for several reasons: if the file is not readable, if there is an error inside the file, and in such cases, the error will be reported to the user in the error.",
+    "Finally, the command will fail if the server is not configured to use an external ACL file."
+  ],
+  "APPEND": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string after the append operation."
+  ],
+  "ASKING": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "AUTH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`, or an error if the password, or username/password pair, is invalid."
+  ],
+  "BGREWRITEAOF": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): a simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success.",
+    "",
+    "The command may reply with an error in certain cases, as documented above."
+  ],
+  "BGSAVE": [
+    "One of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `Background saving started`.",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `Background saving scheduled`."
+  ],
+  "BITCOUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of bits set to 1."
+  ],
+  "BITFIELD": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): each entry being the corresponding result of the sub-command given at the same position.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if OVERFLOW FAIL was given and overflows or underflows are detected."
+  ],
+  "BITFIELD_RO": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): each entry being the corresponding result of the sub-command given at the same position."
+  ],
+  "BITOP": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the size of the string stored in the destination key is equal to the size of the longest input string."
+  ],
+  "BITPOS": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the position of the first bit set to 1 or 0 according to the request",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1`. In case the `bit` argument is 1 and the string is empty or composed of just zero bytes",
+    "",
+    "If we look for set bits (the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.",
+    "",
+    "If we look for clear bits (the bit argument is 0) and the string only contains bits set to 1, the function returns the first bit not part of the string on the right. So if the string is three bytes set to the value `0xff` the command `BITPOS key 0` will return 24, since up to bit 23 all the bits are 1.",
+    "",
+    "The function considers the right of the string as padded with zeros if you look for clear bits and specify no range or the _start_ argument **only**.",
+    "",
+    "However, this behavior changes if you are looking for clear bits and specify a range with both _start_ and _end_.",
+    "If a clear bit isn't found in the specified range, the function returns -1 as the user specified a clear range and there are no 0 bits in that range."
+  ],
+  "BLMOVE": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped from the _source_ and pushed to the _destination_.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the operation timed-out"
+  ],
+  "BLMPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped and the _timeout_ is reached.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element being an array of the popped elements."
+  ],
+  "BLPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): no element could be popped and the timeout expired",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the key from which the element was popped and the value of the popped element."
+  ],
+  "BRPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): no element could be popped and the timeout expired.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the key from which the element was popped and the value of the popped element"
+  ],
+  "BRPOPLPUSH": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped from _source_ and pushed to _destination_.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the timeout is reached."
+  ],
+  "BZMPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+  ],
+  "BZPOPMAX": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped and the _timeout_ expired.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the keyname, popped member, and its score."
+  ],
+  "BZPOPMIN": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped and the _timeout_ expired.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the keyname, popped member, and its score."
+  ],
+  "CLIENT": [],
+  "CLIENT CACHING": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` or an error if the argument is not \"yes\" or \"no\"."
+  ],
+  "CLIENT GETNAME": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the connection name of the current connection.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the connection name was not set."
+  ],
+  "CLIENT GETREDIR": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` when not redirecting notifications to any client.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if client tracking is not enabled.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the ID of the client to which notification are being redirected."
+  ],
+  "CLIENT HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+  ],
+  "CLIENT ID": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the ID of the client."
+  ],
+  "CLIENT INFO": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a unique string for the current client, as described at the `CLIENT LIST` page."
+  ],
+  "CLIENT KILL": [
+    "One of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when called in 3 argument format and the connection has been closed.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): when called in filter/value format, the number of clients killed."
+  ],
+  "CLIENT LIST": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): information and statistics about client connections."
+  ],
+  "CLIENT NO-EVICT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CLIENT NO-TOUCH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CLIENT PAUSE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` or an error if the timeout is invalid."
+  ],
+  "CLIENT REPLY": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when called with `ON`. When called with either `OFF` or `SKIP` sub-commands, no reply is made."
+  ],
+  "CLIENT SETINFO": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the attribute name was successfully set."
+  ],
+  "CLIENT SETNAME": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the connection name was successfully set."
+  ],
+  "CLIENT TRACKING": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned."
+  ],
+  "CLIENT TRACKINGINFO": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of tracking information sections and their respective values."
+  ],
+  "CLIENT UNBLOCK": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the client was unblocked successfully.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the client wasn't unblocked."
+  ],
+  "CLIENT UNPAUSE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CLUSTER": [],
+  "CLUSTER ADDSLOTS": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER ADDSLOTSRANGE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER BUMPEPOCH": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `BUMPED` if the epoch was incremented.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `STILL` if the node already has the greatest configured epoch in the cluster."
+  ],
+  "CLUSTER COUNT-FAILURE-REPORTS": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of active failure reports for the node."
+  ],
+  "CLUSTER COUNTKEYSINSLOT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The number of keys in the specified hash slot, or an error if the hash slot is invalid."
+  ],
+  "CLUSTER DELSLOTS": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER DELSLOTSRANGE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER FAILOVER": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if the client is connected to a node that is already a master."
+  ],
+  "CLUSTER FLUSHSLOTS": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`"
+  ],
+  "CLUSTER FORGET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was executed successfully. Otherwise an error is returned."
+  ],
+  "CLUSTER GETKEYSINSLOT": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array with up to count elements."
+  ],
+  "CLUSTER HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+  ],
+  "CLUSTER INFO": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): A map between named fields and values in the form of `<field>:<value>` lines separated by newlines composed by the two bytes `CRLF`."
+  ],
+  "CLUSTER KEYSLOT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The hash slot number for the specified key"
+  ],
+  "CLUSTER LINKS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array of maps where each map contains various attributes and their values of a cluster link."
+  ],
+  "CLUSTER MEET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. If the address or port specified are invalid an error is returned."
+  ],
+  "CLUSTER MYID": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the node ID."
+  ],
+  "CLUSTER MYSHARDID": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the node's shard ID."
+  ],
+  "CLUSTER NODES": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized cluster configuration."
+  ],
+  "CLUSTER REPLICAS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
+  ],
+  "CLUSTER REPLICATE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER RESET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER SAVECONFIG": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER SET-CONFIG-EPOCH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER SETSLOT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): all the sub-commands return `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER SHARDS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of a map of hash ranges and shard nodes describing individual shards."
+  ],
+  "CLUSTER SLAVES": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
+  ],
+  "CLUSTER SLOTS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): nested list of slot ranges with networking information."
+  ],
+  "COMMAND": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of command details. The order of the commands in the array is random."
+  ],
+  "COMMAND COUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of commands returned by `COMMAND`."
+  ],
+  "COMMAND DOCS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a map, as a flattened array, where each key is a command name, and each value is the documentary information."
+  ],
+  "COMMAND GETKEYS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): list of keys from the given command."
+  ],
+  "COMMAND GETKEYSANDFLAGS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys from the given command and their usage flags."
+  ],
+  "COMMAND HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "COMMAND INFO": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of command details."
+  ],
+  "COMMAND LIST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of command names."
+  ],
+  "CONFIG": [],
+  "CONFIG GET": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of configuration parameters matching the provided arguments."
+  ],
+  "CONFIG HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "CONFIG RESETSTAT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CONFIG REWRITE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when the configuration was rewritten properly. Otherwise an error is returned."
+  ],
+  "CONFIG SET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when the configuration was set properly. Otherwise an error is returned."
+  ],
+  "COPY": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _source_ was copied.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _source_ was not copied."
+  ],
+  "DBSIZE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys in the currently-selected database."
+  ],
+  "DEBUG": [],
+  "DECR": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after decrementing it."
+  ],
+  "DECRBY": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after decrementing it."
+  ],
+  "DEL": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that were removed."
+  ],
+  "DISCARD": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "DUMP": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The serialized value of the key.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the key does not exist."
+  ],
+  "ECHO": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the given string."
+  ],
+  "EVAL": [
+    "The return value depends on the script that was executed."
+  ],
+  "EVALSHA": [
+    "The return value depends on the script that was executed."
+  ],
+  "EVALSHA_RO": [
+    "The return value depends on the script that was executed."
+  ],
+  "EVAL_RO": [
+    "The return value depends on the script that was executed."
+  ],
+  "EXEC": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): each element being the reply to each of the commands in the atomic transaction.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the transaction was aborted because a `WATCH`ed key was touched."
+  ],
+  "EXISTS": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that exist from those specified as arguments."
+  ],
+  "EXPIRE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+  ],
+  "EXPIREAT": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+  ],
+  "EXPIRETIME": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the expiration Unix timestamp in seconds.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration time.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+  ],
+  "FAILOVER": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed."
+  ],
+  "FCALL": [
+    "The return value depends on the function that was executed."
+  ],
+  "FCALL_RO": [
+    "The return value depends on the function that was executed."
+  ],
+  "FLUSHALL": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FLUSHDB": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION": [],
+  "FUNCTION DELETE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION DUMP": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized payload"
+  ],
+  "FUNCTION FLUSH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"
+  ],
+  "FUNCTION KILL": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION LIST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): information about functions and libraries."
+  ],
+  "FUNCTION LOAD": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the library name that was loaded."
+  ],
+  "FUNCTION RESTORE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION STATS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): information about the function that's currently running and information about the available execution engines."
+  ],
+  "GEOADD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): When used without optional arguments, the number of elements added to the sorted set (excluding score updates).  If the CH option is specified, the number of elements that were changed (added or updated)."
+  ],
+  "GEODIST": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): one or both of the elements are missing.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): distance as a double (represented as a string) in the specified units."
+  ],
+  "GEOHASH": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is the Geohash corresponding to each member name passed as an argument to the command."
+  ],
+  "GEOPOS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command. Non-existing elements are reported as [Nil reply](/docs/reference/protocol-spec#bulk-strings) elements of the array."
+  ],
+  "GEORADIUS": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    1. The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    1. The Geohash integer.",
+    "    1. The coordinates as a two items x,y array (longitude,latitude).",
+    "",
+    "For example, the command `GEORADIUS Sicily 15 37 200 km WITHCOORD WITHDIST` will return each item in the following way:",
+    "",
+    "`[\"Palermo\",\"190.4424\",[\"13.361389338970184\",\"38.115556395496299\"]]`"
+  ],
+  "GEORADIUSBYMEMBER": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    * The Geohash integer.",
+    "    * The coordinates as a two items x,y array (longitude,latitude)."
+  ],
+  "GEORADIUSBYMEMBER_RO": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    * The Geohash integer.",
+    "    * The coordinates as a two items x,y array (longitude,latitude)."
+  ],
+  "GEORADIUS_RO": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    * The Geohash integer.",
+    "    * The coordinates as a two items x,y array (longitude,latitude)."
+  ],
+  "GEOSEARCH": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    * The Geohash integer.",
+    "    * The coordinates as a two items x,y array (longitude,latitude)."
+  ],
+  "GEOSEARCHSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set"
+  ],
+  "GET": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist."
+  ],
+  "GETBIT": [
+    "The bit value stored at _offset_, one of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0`.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1`."
+  ],
+  "GETDEL": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist or if the key's value type is not a string."
+  ],
+  "GETEX": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of `key`",
+    "[Nil reply](/docs/reference/protocol-spec#bulk-strings): if `key` does not exist."
+  ],
+  "GETRANGE": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+  ],
+  "GETSET": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the old value stored at the key.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist."
+  ],
+  "HDEL": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of fields that were removed from the hash, excluding any specified but non-existing fields."
+  ],
+  "HELLO": [
+    "[Map reply](/docs/reference/protocol-spec#maps): a list of server properties.",
+    "[Simple error reply](/docs/reference/protocol-spec#simple-errors): if the `protover` requested does not exist."
+  ],
+  "HEXISTS": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the hash does not contain the field, or the key does not exist.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the hash contains the field."
+  ],
+  "HGET": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The value associated with the field.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): If the field is not present in the hash or key does not exist."
+  ],
+  "HGETALL": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of fields and their values stored in the hash, or an empty list when key does not exist."
+  ],
+  "HINCRBY": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the field after the increment operation."
+  ],
+  "HINCRBYFLOAT": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the field after the increment operation."
+  ],
+  "HKEYS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of fields in the hash, or an empty list when the key does not exist"
+  ],
+  "HLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of fields in the hash, or 0 when the key does not exist."
+  ],
+  "HMGET": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values associated with the given fields, in the same order as they are requested."
+  ],
+  "HMSET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "HRANDFIELD": [
+    "Any of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key doesn't exist",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a single, randomly selected field when the `count` option is not used",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list containing `count` fields when the `count` option is used, or an empty array if the key does not exists.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of fields and their values when `count` and `WITHVALUES` were both used."
+  ],
+  "HSCAN": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a two-element array.",
+    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) of field/value pairs that were scanned."
+  ],
+  "HSET": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of fields that were added."
+  ],
+  "HSETNX": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the field already exists in the hash and no operation was performed.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the field is a new field in the hash and the value was set."
+  ],
+  "HSTRLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the string length of the value associated with the _field_, or zero when the _field_ isn't present in the hash or the _key_ doesn't exist at all."
+  ],
+  "HVALS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values in the hash, or an empty list when the key does not exist"
+  ],
+  "INCR": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after the increment."
+  ],
+  "INCRBY": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after the increment."
+  ],
+  "INCRBYFLOAT": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key after the increment."
+  ],
+  "INFO": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a map of info fields, one field per line in the form of <field>:<value> where the value can be a comma separated map like <key>=<val>. Also contains section header lines starting with `#` and blank lines.",
+    "",
+    "Lines can contain a section name (starting with a # character) or a property. All the properties are in the form of `field:value` terminated by `\r\n`."
+  ],
+  "KEYS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys matching _pattern_."
+  ],
+  "LASTSAVE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): UNIX TIME of the last DB save executed with success."
+  ],
+  "LATENCY": [],
+  "LATENCY DOCTOR": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a human readable latency analysis report."
+  ],
+  "LATENCY GRAPH": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): Latency graph"
+  ],
+  "LATENCY HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "LATENCY HISTOGRAM": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets."
+  ],
+  "LATENCY HISTORY": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is a two elements array representing the timestamp and the latency of the event."
+  ],
+  "LATENCY LATEST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements."
+  ],
+  "LATENCY RESET": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of event time series that were reset."
+  ],
+  "LCS": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the longest common subsequence.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the length of the longest common subsequence when _LEN_ is given.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array with the LCS length and all the ranges in both the strings when _IDX_ is given."
+  ],
+  "LINDEX": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when _index_ is out of range.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the requested element."
+  ],
+  "LINSERT": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the list length after a successful insert operation.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` when the key doesn't exist.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` when the pivot wasn't found."
+  ],
+  "LLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list."
+  ],
+  "LMOVE": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped and pushed."
+  ],
+  "LMPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if no element could be popped.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped and the second element being an array of elements."
+  ],
+  "LOLWUT": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a string containing generative computer art and the Redis version."
+  ],
+  "LPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the value of the first element.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of popped elements."
+  ],
+  "LPOS": [
+    "Any of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if there is no matching element.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): an integer representing the matching element.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): If the COUNT option is given, an array of integers representing the matching elements (or an empty array if there are no matches)."
+  ],
+  "LPUSH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+  ],
+  "LPUSHX": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+  ],
+  "LRANGE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of elements in the specified range, or an empty array if the key doesn't exist."
+  ],
+  "LREM": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of removed elements."
+  ],
+  "LSET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "LTRIM": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "MEMORY": [],
+  "MEMORY DOCTOR": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a memory problems report."
+  ],
+  "MEMORY HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"
+  ],
+  "MEMORY MALLOC-STATS": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the memory allocator's internal statistics report"
+  ],
+  "MEMORY PURGE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "MEMORY STATS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of memory usage metrics and their values."
+  ],
+  "MEMORY USAGE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the memory usage in bytes.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist."
+  ],
+  "MGET": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values at the specified keys."
+  ],
+  "MIGRATE": [
+    "One of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `NOKEY` when no keys were found in the source instance."
+  ],
+  "MODULE": [],
+  "MODULE HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "MODULE LIST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): list of loaded modules. Each element in the list represents a represents a module, and is in itself a list of property names and their values. The following properties is reported for each loaded module:",
+    "* name: the name of the module.",
+    "* ver: the version of the module."
+  ],
+  "MODULE LOAD": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was loaded."
+  ],
+  "MODULE LOADEX": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was loaded."
+  ],
+  "MODULE UNLOAD": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was unloaded."
+  ],
+  "MONITOR": [
+    "**Non-standard return value**. Dumps the received commands in an infinite flow."
+  ],
+  "MOVE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _key_ was moved.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _key_ wasn't moved."
+  ],
+  "MSET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): always `OK` because `MSET` can't fail."
+  ],
+  "MSETNX": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if no key was set (at least one key already existed).",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if all the keys were set."
+  ],
+  "MULTI": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "OBJECT": [],
+  "OBJECT ENCODING": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key doesn't exist.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the encoding of the object."
+  ],
+  "OBJECT FREQ": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the counter's value."
+  ],
+  "OBJECT HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"
+  ],
+  "OBJECT IDLETIME": [
+    "One of the following:",
+    "[Integer reply](/docs/reference/protocol-spec#integers): the idle time in seconds.",
+    "[Nil reply](/docs/reference/protocol-spec#bulk-strings): if _key_ doesn't exist."
+  ],
+  "OBJECT REFCOUNT": [
+    "One of the following:",
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of references.",
+    "[Nil reply](/docs/reference/protocol-spec#bulk-strings): if _key_ doesn't exist."
+  ],
+  "PERSIST": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _key_ does not exist or does not have an associated timeout.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout has been removed."
+  ],
+  "PEXPIRE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0`if the timeout was not set. For example, if the key doesn't exist, or the operation skipped because of the provided arguments.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+  ],
+  "PEXPIREAT": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set. For example, if the key doesn't exist, or the operation was skipped due to the provided arguments."
+  ],
+  "PEXPIRETIME": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): Expiration Unix timestamp in milliseconds.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration time.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+  ],
+  "PFADD": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if at least one HyperLogLog internal register was altered.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if no HyperLogLog internal registers were altered."
+  ],
+  "PFCOUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the approximated number of unique elements observed via `PFADD`."
+  ],
+  "PFDEBUG": [],
+  "PFMERGE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "PFSELFTEST": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "PING": [
+    "Any of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `PONG` when no argument is provided.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the provided argument."
+  ],
+  "PSETEX": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "PSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each pattern, one message with the first element being the string `psubscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "PSYNC": [
+    "**Non-standard return value**, a bulk transfer of the data followed by `PING` and write requests from the master."
+  ],
+  "PTTL": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): TTL in milliseconds.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+  ],
+  "PUBLISH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of clients that received the message. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count."
+  ],
+  "PUBSUB": [],
+  "PUBSUB CHANNELS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of active channels, optionally matching the specified pattern."
+  ],
+  "PUBSUB HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "PUBSUB NUMPAT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of patterns all the clients are subscribed to."
+  ],
+  "PUBSUB NUMSUB": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): the number of subscribers per channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers"
+  ],
+  "PUBSUB SHARDCHANNELS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of active channels, optionally matching the specified pattern."
+  ],
+  "PUBSUB SHARDNUMSUB": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): the number of subscribers per shard channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers."
+  ],
+  "PUNSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each pattern, one message with the first element being the string `punsubscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "QUIT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): OK."
+  ],
+  "RANDOMKEY": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when the database is empty.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a random key in database."
+  ],
+  "READONLY": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "READWRITE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RENAME": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RENAMENX": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _key_ was renamed to _newkey_.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _newkey_ already exists."
+  ],
+  "REPLCONF": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "REPLICAOF": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RESET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `RESET`."
+  ],
+  "RESTORE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RESTORE-ASKING": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "ROLE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): where the first element is one of `master`, `slave`, or `sentinel`, and the additional elements are role-specific as illustrated above."
+  ],
+  "RPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the value of the last element.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of popped elements."
+  ],
+  "RPOPLPUSH": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped and pushed.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the source list is empty."
+  ],
+  "RPUSH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+  ],
+  "RPUSHX": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+  ],
+  "SADD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements that were added to the set, not including all the elements already present in the set."
+  ],
+  "SAVE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SCAN": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, an array with two elements.",
+    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) with the names of scanned keys."
+  ],
+  "SCARD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the cardinality (number of elements) of the set, or `0` if the key does not exist."
+  ],
+  "SCRIPT": [],
+  "SCRIPT DEBUG": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SCRIPT EXISTS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array of integers that correspond to the specified SHA1 digest arguments."
+  ],
+  "SCRIPT FLUSH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SCRIPT HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "SCRIPT KILL": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SCRIPT LOAD": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the SHA1 digest of the script added into the script cache."
+  ],
+  "SDIFF": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list with members of the resulting set."
+  ],
+  "SDIFFSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set."
+  ],
+  "SELECT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SET": [
+    "Any of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): `GET` not given: Operation was aborted (conflict with one of the `XX`/`NX` options).",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. `GET` not given: The key was set.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): `GET` given: The key didn't exist before the `SET`.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `GET` given: The previous value of the key."
+  ],
+  "SETBIT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the original bit value stored at _offset_."
+  ],
+  "SETEX": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SETNX": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the key was not set.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the key was set."
+  ],
+  "SETRANGE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string after it was modified by the command."
+  ],
+  "SHUTDOWN": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if _ABORT_ was specified and shutdown was aborted. On successful shutdown, nothing is returned because the server quits and the connection is closed. On failure, an error is returned."
+  ],
+  "SINTER": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list with the members of the resulting set."
+  ],
+  "SINTERCARD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting intersection."
+  ],
+  "SINTERSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set."
+  ],
+  "SISMEMBER": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the element is not a member of the set, or when the key does not exist.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the element is a member of the set."
+  ],
+  "SLAVEOF": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SLOWLOG": [],
+  "SLOWLOG GET": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of slow log entries per the above format."
+  ],
+  "SLOWLOG HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "SLOWLOG LEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries in the slow log."
+  ],
+  "SLOWLOG RESET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SMEMBERS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): all members of the set."
+  ],
+  "SMISMEMBER": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list representing the membership of the given elements, in the same order as they are requested."
+  ],
+  "SMOVE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the element is moved.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the element is not a member of _source_ and no operation was performed."
+  ],
+  "SORT": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): without passing the _STORE_ option, the command returns a list of sorted elements.",
+    "[Integer reply](/docs/reference/protocol-spec#integers): when the _STORE_ option is specified, the command returns the number of sorted elements in the destination list."
+  ],
+  "SORT_RO": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sorted elements."
+  ],
+  "SPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the removed member.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a aist of the removed members."
+  ],
+  "SPUBLISH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of clients that received the message. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count"
+  ],
+  "SRANDMEMBER": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or a [Nil reply](/docs/reference/protocol-spec#bulk-strings) when _key_ doesn't exist.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when the optional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist."
+  ],
+  "SREM": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members that were removed from the set, not including non existing members."
+  ],
+  "SSCAN": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, an array with two elements:",
+    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) with the names of scanned members."
+  ],
+  "SSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each shard channel, one message with the first element being the string `ssubscribe` is pushed as a confirmation that the command succeeded. Note that this command can also return a -MOVED redirect."
+  ],
+  "STRLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string stored at key, or 0 when the key does not exist."
+  ],
+  "SUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each channel, one message with the first element being the string `subscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "SUBSTR": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+  ],
+  "SUNION": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list with members of the resulting set."
+  ],
+  "SUNIONSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set."
+  ],
+  "SUNSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each shard channel, one message with the first element being the string `sunsubscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "SWAPDB": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SYNC": [
+    "**Non-standard return value**, a bulk transfer of the data followed by `PING` and write requests from the master."
+  ],
+  "TIME": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, a two-element array consisting of the Unix timestamp in seconds and the microseconds' count."
+  ],
+  "TOUCH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of touched keys."
+  ],
+  "TTL": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): TTL in seconds.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+  ],
+  "TYPE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): the type of _key_, or `none` when _key_ doesn't exist."
+  ],
+  "UNLINK": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that were unlinked."
+  ],
+  "UNSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each channel, one message with the first element being the string `unsubscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "UNWATCH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "WAIT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the command returns the number of replicas reached by all the writes performed in the context of the current connection."
+  ],
+  "WAITAOF": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): The command returns an array of two integers:",
+    "1. The first is the number of local Redises (0 or 1) that have fsynced to AOF  all writes performed in the context of the current connection",
+    "2. The second is the number of replicas that have acknowledged doing the same."
+  ],
+  "WATCH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "XACK": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged."
+  ],
+  "XADD": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the NOMKSTREAM option is given and the key doesn't exist."
+  ],
+  "XAUTOCLAIM": [
+    "[Array reply](/docs/reference/protocol-spec#arrays), specifically, an array with three elements:",
+    "1. A stream ID to be used as the _start_ argument for the next call to XAUTOCLAIM.",
+    "2. An [Array reply](/docs/reference/protocol-spec#arrays) containing all the successfully claimed messages in the same format as `XRANGE`.",
+    "3. An [Array reply](/docs/reference/protocol-spec#arrays) containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found."
+  ],
+  "XCLAIM": [
+    "Any of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when the _JUSTID_ option is specified, an array of IDs of messages successfully claimed.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of stream entries, each of which contains an array of two elements, the entry ID and the entry data itself."
+  ],
+  "XDEL": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries that were deleted."
+  ],
+  "XGROUP": [],
+  "XGROUP CREATE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "XGROUP CREATECONSUMER": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of created consumers, either 0 or 1."
+  ],
+  "XGROUP DELCONSUMER": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of pending messages the consumer had before it was deleted."
+  ],
+  "XGROUP DESTROY": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of destroyed consumer groups, either 0 or 1."
+  ],
+  "XGROUP HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "XGROUP SETID": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "XINFO": [],
+  "XINFO CONSUMERS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of consumers and their attributes."
+  ],
+  "XINFO GROUPS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of consumer groups."
+  ],
+  "XINFO HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "XINFO STREAM": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when the _FULL_ argument is used, a list of information about a stream in summary form.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when the _FULL_ argument is used, a list of information about a stream in extended form."
+  ],
+  "XLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries of the stream at _key_."
+  ],
+  "XPENDING": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): different data depending on the way XPENDING is called, as explained on this page."
+  ],
+  "XRANGE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of stream entries with IDs matching the specified range."
+  ],
+  "XREAD": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array where each element is an array composed of a two elements containing the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
+  ],
+  "XREADGROUP": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array where each element is an array composed of a two elements containing the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
+  ],
+  "XREVRANGE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): The command returns the entries with IDs matching the specified range. The returned entries are complete, which means that the ID and all the fields they are composed of are returned. Moreover, the entries are returned with their fields and values in the same order as `XADD` added them."
+  ],
+  "XSETID": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "XTRIM": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The number of entries deleted from the stream."
+  ],
+  "ZADD": [
+    "Any of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new members when the _CH_ option is not used.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new or updated members when the _CH_ option is used.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the updated score of the member when the _INCR_ option is used."
+  ],
+  "ZCARD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the cardinality (number of members) of the sorted set, or 0 if the key doesn't exist."
+  ],
+  "ZCOUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the specified score range."
+  ],
+  "ZDIFF": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the result of the difference including, optionally, scores when the _WITHSCORES_ option is used."
+  ],
+  "ZDIFFSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting sorted set at _destination_."
+  ],
+  "ZINCRBY": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the new score of _member_ as a double precision floating point number."
+  ],
+  "ZINTER": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the result of the intersection including, optionally, scores when the _WITHSCORES_ option is used."
+  ],
+  "ZINTERCARD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting intersection."
+  ],
+  "ZINTERSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting sorted set at the _destination_."
+  ],
+  "ZLEXCOUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the specified score range."
+  ],
+  "ZMPOP": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+  ],
+  "ZMSCORE": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the member does not exist in the sorted set.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) _member_ scores as double-precision floating point numbers."
+  ],
+  "ZPOPMAX": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of popped elements and scores."
+  ],
+  "ZPOPMIN": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of popped elements and scores."
+  ],
+  "ZRANDMEMBER": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or [Nil reply](/docs/reference/protocol-spec#bulk-strings) when _key_ doesn't exist.",
+    "[Array reply](/docs/reference/protocol-spec#arrays): when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
+  ],
+  "ZRANGE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given."
+  ],
+  "ZRANGEBYLEX": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of elements in the specified score range."
+  ],
+  "ZRANGEBYSCORE": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of the members with, optionally, their scores in the specified score range."
+  ],
+  "ZRANGESTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting sorted set."
+  ],
+  "ZRANK": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist or the member does not exist in the sorted set.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the rank of the member when _WITHSCORES_ is not used.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the rank and score of the member when _WITHSCORES_ is used."
+  ],
+  "ZREM": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed from the sorted set, not including non-existing members."
+  ],
+  "ZREMRANGEBYLEX": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed."
+  ],
+  "ZREMRANGEBYRANK": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed."
+  ],
+  "ZREMRANGEBYSCORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed."
+  ],
+  "ZREVRANGE": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified range, optionally with their scores if _WITHSCORE_ was used."
+  ],
+  "ZREVRANGEBYLEX": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified score range."
+  ],
+  "ZREVRANGEBYSCORE": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of the members and, optionally, their scores in the specified score range."
+  ],
+  "ZREVRANK": [
+    "One of the following:",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist or the member does not exist in the sorted set.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): The rank of the member when _WITHSCORE_ is not used.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): The rank and score of the member when _WITHSCORE_ is used."
+  ],
+  "ZSCAN": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): cursor and scan response in array form."
+  ],
+  "ZSCORE": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the score of the member (a double-precision floating point number), represented as a string.",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if _member_ does not exist in the sorted set, or the key does not exist."
+  ],
+  "ZUNION": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): the result of the union with, optionally, their scores when _WITHSCORES_ is used."
+  ],
+  "ZUNIONSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting sorted set."
+  ]
+}

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -1,0 +1,1383 @@
+{
+  "ACL": [],
+  "ACL CAT": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL categories or commands in a given category.",
+    "* [Simple error reply](/docs/reference/protocol-spec#simple-errors): the command returns an error if an invalid category name is given."
+  ],
+  "ACL DELUSER": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
+  ],
+  "ACL DRYRUN": [
+    "Any of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): an error describing why the user can't execute the command."
+  ],
+  "ACL GENPASS": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4."
+  ],
+  "ACL GETUSER": [
+    "One of the following:",
+    "* [Map reply](/docs/reference/protocol-spec#maps): a set of ACL rule definitions for the user",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if user does not exist."
+  ],
+  "ACL HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+  ],
+  "ACL LIST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements."
+  ],
+  "ACL LOAD": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
+    "",
+    "The command may fail with an error for several reasons: if the file is not readable, if there is an error inside the file, and in such cases, the error will be reported to the user in the error.",
+    "Finally, the command will fail if the server is not configured to use an external ACL file."
+  ],
+  "ACL LOG": [
+    "When called to show security events:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL security events.",
+    "When called with `RESET`:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the security log was cleared."
+  ],
+  "ACL SAVE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`.",
+    "The command may fail with an error for several reasons: if the file cannot be written or if the server is not configured to use an external ACL file."
+  ],
+  "ACL SETUSER": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`.",
+    "If the rules contain errors, the error is returned."
+  ],
+  "ACL USERS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): list of existing ACL users."
+  ],
+  "ACL WHOAMI": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the username of the current connection."
+  ],
+  "APPEND": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string after the append operation."
+  ],
+  "ASKING": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "AUTH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`, or an error if the password, or username/password pair, is invalid."
+  ],
+  "BGREWRITEAOF": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success.",
+    "",
+    "The command may reply with an error in certain cases, as documented above."
+  ],
+  "BGSAVE": [
+    "One of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `Background saving started`.",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `Background saving scheduled`."
+  ],
+  "BITCOUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of bits set to 1."
+  ],
+  "BITFIELD": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): each entry being the corresponding result of the sub-command given at the same position.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if OVERFLOW FAIL was given and overflows or underflows are detected."
+  ],
+  "BITFIELD_RO": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): each entry being the corresponding result of the sub-command given at the same position."
+  ],
+  "BITOP": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the size of the string stored in the destination key is equal to the size of the longest input string."
+  ],
+  "BITPOS": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the position of the first bit set to 1 or 0 according to the request",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1`. In case the `bit` argument is 1 and the string is empty or composed of just zero bytes",
+    "",
+    "If we look for set bits (the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.",
+    "",
+    "If we look for clear bits (the bit argument is 0) and the string only contains bits set to 1, the function returns the first bit not part of the string on the right. So if the string is three bytes set to the value `0xff` the command `BITPOS key 0` will return 24, since up to bit 23 all the bits are 1.",
+    "",
+    "The function considers the right of the string as padded with zeros if you look for clear bits and specify no range or the _start_ argument **only**.",
+    "",
+    "However, this behavior changes if you are looking for clear bits and specify a range with both _start_ and _end_.",
+    "If a clear bit isn't found in the specified range, the function returns -1 as the user specified a clear range and there are no 0 bits in that range."
+  ],
+  "BLMOVE": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped from the _source_ and pushed to the _destination_.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): the operation timed-out"
+  ],
+  "BLMPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped and the _timeout_ is reached.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element being an array of the popped elements."
+  ],
+  "BLPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): no element could be popped and the timeout expired",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the key from which the element was popped and the value of the popped element."
+  ],
+  "BRPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): no element could be popped and the timeout expired.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the key from which the element was popped and the value of the popped element"
+  ],
+  "BRPOPLPUSH": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped from _source_ and pushed to _destination_.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): the timeout is reached."
+  ],
+  "BZMPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+  ],
+  "BZPOPMAX": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped and the _timeout_ expired.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the keyname, popped member, and its score."
+  ],
+  "BZPOPMIN": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped and the _timeout_ expired.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the keyname, popped member, and its score."
+  ],
+  "CLIENT": [],
+  "CLIENT CACHING": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` or an error if the argument is not \"yes\" or \"no\"."
+  ],
+  "CLIENT GETNAME": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the connection name of the current connection.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): the connection name was not set."
+  ],
+  "CLIENT GETREDIR": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` when not redirecting notifications to any client.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if client tracking is not enabled.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the ID of the client to which notification are being redirected."
+  ],
+  "CLIENT HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+  ],
+  "CLIENT ID": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the ID of the client."
+  ],
+  "CLIENT INFO": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a unique string for the current client, as described at the `CLIENT LIST` page."
+  ],
+  "CLIENT KILL": [
+    "One of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when called in 3 argument format and the connection has been closed.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): when called in filter/value format, the number of clients killed."
+  ],
+  "CLIENT LIST": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): information and statistics about client connections."
+  ],
+  "CLIENT NO-EVICT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CLIENT NO-TOUCH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CLIENT PAUSE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` or an error if the timeout is invalid."
+  ],
+  "CLIENT REPLY": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when called with `ON`. When called with either `OFF` or `SKIP` sub-commands, no reply is made."
+  ],
+  "CLIENT SETINFO": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the attribute name was successfully set."
+  ],
+  "CLIENT SETNAME": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the connection name was successfully set."
+  ],
+  "CLIENT TRACKING": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned."
+  ],
+  "CLIENT TRACKINGINFO": [
+    "[Map reply](/docs/reference/protocol-spec#maps): a list of tracking information sections and their respective values."
+  ],
+  "CLIENT UNBLOCK": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the client was unblocked successfully.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the client wasn't unblocked."
+  ],
+  "CLIENT UNPAUSE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CLUSTER": [],
+  "CLUSTER ADDSLOTS": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER ADDSLOTSRANGE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER BUMPEPOCH": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `BUMPED` if the epoch was incremented.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `STILL` if the node already has the greatest configured epoch in the cluster."
+  ],
+  "CLUSTER COUNT-FAILURE-REPORTS": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of active failure reports for the node."
+  ],
+  "CLUSTER COUNTKEYSINSLOT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The number of keys in the specified hash slot, or an error if the hash slot is invalid."
+  ],
+  "CLUSTER DELSLOTS": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER DELSLOTSRANGE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER FAILOVER": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if the client is connected to a node that is already a master."
+  ],
+  "CLUSTER FLUSHSLOTS": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CLUSTER FORGET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was executed successfully. Otherwise an error is returned."
+  ],
+  "CLUSTER GETKEYSINSLOT": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array with up to count elements."
+  ],
+  "CLUSTER HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+  ],
+  "CLUSTER INFO": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): A map between named fields and values in the form of <field>:<value> lines separated by newlines composed by the two bytes CRLF"
+  ],
+  "CLUSTER KEYSLOT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The hash slot number for the specified key"
+  ],
+  "CLUSTER LINKS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array of [Map reply](/docs/reference/protocol-spec#maps) where each map contains various attributes and their values of a cluster link."
+  ],
+  "CLUSTER MEET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. If the address or port specified are invalid an error is returned."
+  ],
+  "CLUSTER MYID": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the node ID."
+  ],
+  "CLUSTER MYSHARDID": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the node's shard ID."
+  ],
+  "CLUSTER NODES": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized cluster configuration."
+  ],
+  "CLUSTER REPLICAS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
+  ],
+  "CLUSTER REPLICATE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER RESET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER SAVECONFIG": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER SET-CONFIG-EPOCH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER SETSLOT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): all the sub-commands return `OK` if the command was successful. Otherwise an error is returned."
+  ],
+  "CLUSTER SHARDS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of [Map reply](/docs/reference/protocol-spec#maps) of hash ranges and shard nodes describing individual shards."
+  ],
+  "CLUSTER SLAVES": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
+  ],
+  "CLUSTER SLOTS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): nested list of slot ranges with networking information."
+  ],
+  "COMMAND": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of command details. The order of the commands in the array is random."
+  ],
+  "COMMAND COUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of commands returned by `COMMAND`."
+  ],
+  "COMMAND DOCS": [
+    "[Map reply](/docs/reference/protocol-spec#maps): a map where each key is a command name, and each value is the documentary information."
+  ],
+  "COMMAND GETKEYS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys from the given command."
+  ],
+  "COMMAND GETKEYSANDFLAGS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys from the given command and their usage flags."
+  ],
+  "COMMAND HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "COMMAND INFO": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of command details."
+  ],
+  "COMMAND LIST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of command names."
+  ],
+  "CONFIG": [],
+  "CONFIG GET": [
+    "[Map reply](/docs/reference/protocol-spec#maps): a list of configuration parameters matching the provided arguments."
+  ],
+  "CONFIG HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "CONFIG RESETSTAT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "CONFIG REWRITE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when the configuration was rewritten properly. Otherwise an error is returned."
+  ],
+  "CONFIG SET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when the configuration was set properly. Otherwise an error is returned."
+  ],
+  "COPY": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _source_ was copied.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _source_ was not copied."
+  ],
+  "DBSIZE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys in the currently-selected database."
+  ],
+  "DEBUG": [],
+  "DECR": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after decrementing it."
+  ],
+  "DECRBY": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after decrementing it."
+  ],
+  "DEL": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that were removed."
+  ],
+  "DISCARD": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "DUMP": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized value of the key.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): the key does not exist."
+  ],
+  "ECHO": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the given string."
+  ],
+  "EVAL": [
+    "The return value depends on the script that was executed."
+  ],
+  "EVALSHA": [
+    "The return value depends on the script that was executed."
+  ],
+  "EVALSHA_RO": [
+    "The return value depends on the script that was executed."
+  ],
+  "EVAL_RO": [
+    "The return value depends on the script that was executed."
+  ],
+  "EXEC": [
+    "One of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): each element being the reply to each of the commands in the atomic transaction.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): the transaction was aborted because a `WATCH`ed key was touched."
+  ],
+  "EXISTS": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that exist from those specified as arguments."
+  ],
+  "EXPIRE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+  ],
+  "EXPIREAT": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+  ],
+  "EXPIRETIME": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the expiration Unix timestamp in seconds.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration time.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+  ],
+  "FAILOVER": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed."
+  ],
+  "FCALL": [
+    "The return value depends on the function that was executed."
+  ],
+  "FCALL_RO": [
+    "The return value depends on the function that was executed."
+  ],
+  "FLUSHALL": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FLUSHDB": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION": [],
+  "FUNCTION DELETE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION DUMP": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized payload"
+  ],
+  "FUNCTION FLUSH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "FUNCTION KILL": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION LIST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): information about functions and libraries."
+  ],
+  "FUNCTION LOAD": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the library name that was loaded."
+  ],
+  "FUNCTION RESTORE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "FUNCTION STATS": [
+    "[Map reply](/docs/reference/protocol-spec#maps): information about the function that's currently running and information about the available execution engines."
+  ],
+  "GEOADD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): When used without optional arguments, the number of elements added to the sorted set (excluding score updates).  If the CH option is specified, the number of elements that were changed (added or updated)."
+  ],
+  "GEODIST": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): one or both of the elements are missing.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): distance as a double (represented as a string) in the specified units."
+  ],
+  "GEOHASH": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): An array where each element is the Geohash corresponding to each member name passed as an argument to the command."
+  ],
+  "GEOPOS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command. Non-existing elements are reported as [Null reply](/docs/reference/protocol-spec#nulls) elements of the array."
+  ],
+  "GEORADIUS": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    1. The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    1. The Geohash integer.",
+    "    1. The coordinates as a two items x,y array (longitude,latitude).",
+    "",
+    "For example, the command `GEORADIUS Sicily 15 37 200 km WITHCOORD WITHDIST` will return each item in the following way:",
+    "",
+    "`[\"Palermo\",\"190.4424\",[\"13.361389338970184\",\"38.115556395496299\"]]`"
+  ],
+  "GEORADIUSBYMEMBER": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    * The Geohash integer.",
+    "    * The coordinates as a two items x,y array (longitude,latitude)."
+  ],
+  "GEORADIUSBYMEMBER_RO": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    * The Geohash integer.",
+    "    * The coordinates as a two items x,y array (longitude,latitude)."
+  ],
+  "GEORADIUS_RO": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    * The Geohash integer.",
+    "    * The coordinates as a two items x,y array (longitude,latitude)."
+  ],
+  "GEOSEARCH": [
+    "One of the following:",
+    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
+    "    * The Geohash integer.",
+    "    * The coordinates as a two items x,y array (longitude,latitude)."
+  ],
+  "GEOSEARCHSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set"
+  ],
+  "GET": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): key does not exist."
+  ],
+  "GETBIT": [
+    "The bit value stored at _offset_, one of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0`.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1`."
+  ],
+  "GETDEL": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist or if the key's value type is not a string."
+  ],
+  "GETEX": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of `key`",
+    "[Null reply](/docs/reference/protocol-spec#nulls): if `key` does not exist."
+  ],
+  "GETRANGE": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+  ],
+  "GETSET": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the old value stored at the key.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist."
+  ],
+  "HDEL": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The number of fields that were removed from the hash, excluding any specified but non-existing fields."
+  ],
+  "HELLO": [
+    "[Map reply](/docs/reference/protocol-spec#maps): a list of server properties.",
+    "[Simple error reply](/docs/reference/protocol-spec#simple-errors): if the `protover` requested does not exist."
+  ],
+  "HEXISTS": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the hash does not contain the field, or the key does not exist.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the hash contains the field."
+  ],
+  "HGET": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The value associated with the field.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): If the field is not present in the hash or key does not exist."
+  ],
+  "HGETALL": [
+    "[Map reply](/docs/reference/protocol-spec#maps): a map of fields and their values stored in the hash, or an empty list when key does not exist."
+  ],
+  "HINCRBY": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the field after the increment operation."
+  ],
+  "HINCRBYFLOAT": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The value of the field after the increment operation."
+  ],
+  "HKEYS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of fields in the hash, or an empty list when the key does not exist."
+  ],
+  "HLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of the fields in the hash, or 0 when the key does not exist."
+  ],
+  "HMGET": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values associated with the given fields, in the same order as they are requested."
+  ],
+  "HMSET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "HRANDFIELD": [
+    "Any of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key doesn't exist",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a single, randomly selected field when the `count` option is not used",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list containing `count` fields when the `count` option is used, or an empty array if the key does not exists.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of fields and their values when `count` and `WITHVALUES` were both used."
+  ],
+  "HSCAN": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a two-element array.",
+    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) of field/value pairs that were scanned."
+  ],
+  "HSET": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of fields that were added."
+  ],
+  "HSETNX": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the field already exists in the hash and no operation was performed.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the field is a new field in the hash and the value was set."
+  ],
+  "HSTRLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the string length of the value associated with the _field_, or zero when the _field_ isn't present in the hash or the _key_ doesn't exist at all."
+  ],
+  "HVALS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values in the hash, or an empty list when the key does not exist."
+  ],
+  "INCR": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after the increment."
+  ],
+  "INCRBY": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after the increment."
+  ],
+  "INCRBYFLOAT": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key after the increment."
+  ],
+  "INFO": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a map of info fields, one field per line in the form of <field>:<value> where the value can be a comma separated map like <key>=<val>. Also contains section header lines starting with `#` and blank lines.",
+    "",
+    "Lines can contain a section name (starting with a # character) or a property. All the properties are in the form of `field:value` terminated by `\r\n`."
+  ],
+  "KEYS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys matching _pattern_."
+  ],
+  "LASTSAVE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): UNIX TIME of the last DB save executed with success."
+  ],
+  "LATENCY": [],
+  "LATENCY DOCTOR": [
+    "[Verbatim string reply](/docs/reference/protocol-spec#verbatim-strings): a human readable latency analysis report."
+  ],
+  "LATENCY GRAPH": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): Latency graph"
+  ],
+  "LATENCY HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "LATENCY HISTOGRAM": [
+    "[Map reply](/docs/reference/protocol-spec#maps): a map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets."
+  ],
+  "LATENCY HISTORY": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is a two elements array representing the timestamp and the latency of the event."
+  ],
+  "LATENCY LATEST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements."
+  ],
+  "LATENCY RESET": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of event time series that were reset."
+  ],
+  "LCS": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the longest common subsequence.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the length of the longest common subsequence when _LEN_ is given.",
+    "* [Map reply](/docs/reference/protocol-spec#maps): a map with the LCS length and all the ranges in both the strings when _IDX_ is given."
+  ],
+  "LINDEX": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): when _index_ is out of range.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the requested element."
+  ],
+  "LINSERT": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the list length after a successful insert operation.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` when the key doesn't exist.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` when the pivot wasn't found."
+  ],
+  "LLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list."
+  ],
+  "LMOVE": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped and pushed."
+  ],
+  "LMPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if no element could be popped.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped and the second element being an array of elements."
+  ],
+  "LOLWUT": [
+    "[Verbatim string reply](/docs/reference/protocol-spec#verbatim-strings): a string containing generative computer art and the Redis version."
+  ],
+  "LPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the value of the first element.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of popped elements."
+  ],
+  "LPOS": [
+    "Any of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if there is no matching element.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): an integer representing the matching element.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): If the COUNT option is given, an array of integers representing the matching elements (or an empty array if there are no matches)."
+  ],
+  "LPUSH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+  ],
+  "LPUSHX": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+  ],
+  "LRANGE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of elements in the specified range, or an empty array if the key doesn't exist."
+  ],
+  "LREM": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of removed elements."
+  ],
+  "LSET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "LTRIM": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "MEMORY": [],
+  "MEMORY DOCTOR": [
+    "[Verbatim string reply](/docs/reference/protocol-spec#verbatim-strings): a memory problems report."
+  ],
+  "MEMORY HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "MEMORY MALLOC-STATS": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The memory allocator's internal statistics report."
+  ],
+  "MEMORY PURGE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "MEMORY STATS": [
+    "[Map reply](/docs/reference/protocol-spec#maps): memory usage metrics and their values."
+  ],
+  "MEMORY USAGE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the memory usage in bytes.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist."
+  ],
+  "MGET": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values at the specified keys."
+  ],
+  "MIGRATE": [
+    "One of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `NOKEY` when no keys were found in the source instance."
+  ],
+  "MODULE": [],
+  "MODULE HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"
+  ],
+  "MODULE LIST": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): list of loaded modules. Each element in the list represents a represents a module, and is a [Map reply](/docs/reference/protocol-spec#maps) of property names and their values. The following properties is reported for each loaded module:",
+    "* name: the name of the module.",
+    "* ver: the version of the module."
+  ],
+  "MODULE LOAD": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was loaded."
+  ],
+  "MODULE LOADEX": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was loaded."
+  ],
+  "MODULE UNLOAD": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was unloaded."
+  ],
+  "MONITOR": [
+    "**Non-standard return value**. Dumps the received commands in an infinite flow."
+  ],
+  "MOVE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _key_ was moved.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _key_ wasn't moved."
+  ],
+  "MSET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): always `OK` because `MSET` can't fail."
+  ],
+  "MSETNX": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if no key was set (at least one key already existed).",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if all the keys were set."
+  ],
+  "MULTI": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "OBJECT": [],
+  "OBJECT ENCODING": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key doesn't exist.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the encoding of the object."
+  ],
+  "OBJECT FREQ": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the counter's value."
+  ],
+  "OBJECT HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "OBJECT IDLETIME": [
+    "One of the following:",
+    "[Integer reply](/docs/reference/protocol-spec#integers): the idle time in seconds.",
+    "[Null reply](/docs/reference/protocol-spec#nulls): if _key_ doesn't exist."
+  ],
+  "OBJECT REFCOUNT": [
+    "One of the following:",
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of references.",
+    "[Null reply](/docs/reference/protocol-spec#nulls): if _key_ doesn't exist."
+  ],
+  "PERSIST": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _key_ does not exist or does not have an associated timeout.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout has been removed."
+  ],
+  "PEXPIRE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0`if the timeout was not set. For example, if the key doesn't exist, or the operation skipped because of the provided arguments.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+  ],
+  "PEXPIREAT": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set. For example, if the key doesn't exist, or the operation was skipped due to the provided arguments."
+  ],
+  "PEXPIRETIME": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): Expiration Unix timestamp in milliseconds.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration time.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+  ],
+  "PFADD": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if at least one HyperLogLog internal register was altered.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if no HyperLogLog internal registers were altered."
+  ],
+  "PFCOUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the approximated number of unique elements observed via `PFADD`"
+  ],
+  "PFDEBUG": [],
+  "PFMERGE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "PFSELFTEST": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "PING": [
+    "Any of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `PONG` when no argument is provided.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the provided argument."
+  ],
+  "PSETEX": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "PSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each pattern, one message with the first element being the string `psubscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "PSYNC": [
+    "**Non-standard return value**, a bulk transfer of the data followed by `PING` and write requests from the master."
+  ],
+  "PTTL": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): TTL in milliseconds.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+  ],
+  "PUBLISH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of clients that received the message. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count."
+  ],
+  "PUBSUB": [],
+  "PUBSUB CHANNELS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of active channels, optionally matching the specified pattern."
+  ],
+  "PUBSUB HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "PUBSUB NUMPAT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of patterns all the clients are subscribed to."
+  ],
+  "PUBSUB NUMSUB": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): the number of subscribers per channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers"
+  ],
+  "PUBSUB SHARDCHANNELS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of active channels, optionally matching the specified pattern."
+  ],
+  "PUBSUB SHARDNUMSUB": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): the number of subscribers per shard channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers."
+  ],
+  "PUNSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each pattern, one message with the first element being the string `punsubscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "QUIT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RANDOMKEY": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): when the database is empty.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a random key in the database."
+  ],
+  "READONLY": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "READWRITE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RENAME": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RENAMENX": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _key_ was renamed to _newkey_.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _newkey_ already exists."
+  ],
+  "REPLCONF": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "REPLICAOF": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RESET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `RESET`."
+  ],
+  "RESTORE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "RESTORE-ASKING": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "ROLE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): where the first element is one of `master`, `slave`, or `sentinel`, and the additional elements are role-specific as illustrated above."
+  ],
+  "RPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the value of the last element.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of popped elements."
+  ],
+  "RPOPLPUSH": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped and pushed.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the source list is empty."
+  ],
+  "RPUSH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+  ],
+  "RPUSHX": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+  ],
+  "SADD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements that were added to the set, not including all the elements already present in the set."
+  ],
+  "SAVE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SCAN": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, an array with two elements.",
+    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) with the names of scanned keys."
+  ],
+  "SCARD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The cardinality (number of elements) of the set, or 0 if the key does not exist."
+  ],
+  "SCRIPT": [],
+  "SCRIPT DEBUG": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SCRIPT EXISTS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): an array of integers that correspond to the specified SHA1 digest arguments."
+  ],
+  "SCRIPT FLUSH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SCRIPT HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "SCRIPT KILL": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SCRIPT LOAD": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the SHA1 digest of the script added into the script cache."
+  ],
+  "SDIFF": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list with the members of the resulting set."
+  ],
+  "SDIFFSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set."
+  ],
+  "SELECT": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SENTINEL CKQUORUM": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): Returns OK if the current Sentinel configuration is able to reach the quorum needed to failover a master, and the majority needed to authorize the failover."
+  ],
+  "SENTINEL CONFIG": [
+    "One of the following:",
+    "* [Map reply](/docs/reference/protocol-spec#maps): When 'SENTINEL-CONFIG GET' is called, returns a map.",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. When 'SENTINEL-CONFIG SET' is called, returns OK on success."
+  ],
+  "SENTINEL DEBUG": [
+    "One of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. The configuration update was successful.",
+    "* [Map reply](/docs/reference/protocol-spec#maps): List of configurable time parameters and their values (milliseconds)."
+  ],
+  "SENTINEL FAILOVER": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. Force a fail over as if the master was not reachable, and without asking for agreement to other Sentinels."
+  ],
+  "SENTINEL FLUSHCONFIG": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. Force Sentinel to rewrite its configuration on disk, including the current Sentinel state."
+  ],
+  "SENTINEL GET MASTER-ADDR-BY-NAME": [],
+  "SENTINEL HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): Helpful text about subcommands."
+  ],
+  "SENTINEL INFO CACHE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): This is actually a map, the odd entries are a master name, and the even entries are the last cached INFO output from that master and all its replicas."
+  ],
+  "SENTINEL IS MASTER-DOWN-BY-ADDR": [],
+  "SENTINEL MASTER": [
+    "[Map reply](/docs/reference/protocol-spec#maps): The state and info of the specified master."
+  ],
+  "SENTINEL MASTERS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): List of monitored Redis masters, and their state."
+  ],
+  "SENTINEL MONITOR": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SENTINEL MYID": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): Node ID of the sentinel instance."
+  ],
+  "SENTINEL PENDING SCRIPTS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): List of pending scripts."
+  ],
+  "SENTINEL REMOVE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SENTINEL REPLICAS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): List of replicas for this master, and their state."
+  ],
+  "SENTINEL RESET": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The number of masters that were reset."
+  ],
+  "SENTINEL SENTINELS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): List of sentinel instances, and their state."
+  ],
+  "SENTINEL SET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SENTINEL SIMULATE FAILURE": [
+    "One of the following:",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. The simulated flag was set.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): Supported simulates flags. Returned in case `HELP` was used."
+  ],
+  "SENTINEL SLAVES": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): List of monitored replicas, and their state."
+  ],
+  "SET": [
+    "Any of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): `GET` not given: Operation was aborted (conflict with one of the `XX`/`NX` options).",
+    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. `GET` not given: The key was set.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): `GET` given: The key didn't exist before the `SET`.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `GET` given: The previous value of the key."
+  ],
+  "SETBIT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the original bit value stored at _offset_."
+  ],
+  "SETEX": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SETNX": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the key was not set.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the key was set."
+  ],
+  "SETRANGE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string after it was modified by the command."
+  ],
+  "SHUTDOWN": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if _ABORT_ was specified and shutdown was aborted. On successful shutdown, nothing is returned because the server quits and the connection is closed. On failure, an error is returned."
+  ],
+  "SINTER": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list with the members of the resulting set."
+  ],
+  "SINTERCARD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of the elements in the resulting intersection."
+  ],
+  "SINTERSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of the elements in the result set."
+  ],
+  "SISMEMBER": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the element is not a member of the set, or when the key does not exist.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the element is a member of the set."
+  ],
+  "SLAVEOF": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SLOWLOG": [],
+  "SLOWLOG GET": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of slow log entries per the above format."
+  ],
+  "SLOWLOG HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "SLOWLOG LEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries in the slow log."
+  ],
+  "SLOWLOG RESET": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SMEMBERS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): all members of the set."
+  ],
+  "SMISMEMBER": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list representing the membership of the given elements, in the same order as they are requested."
+  ],
+  "SMOVE": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the element is moved.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the element is not a member of _source_ and no operation was performed."
+  ],
+  "SORT": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): without passing the _STORE_ option, the command returns a list of sorted elements.",
+    "[Integer reply](/docs/reference/protocol-spec#integers): when the _STORE_ option is specified, the command returns the number of sorted elements in the destination list."
+  ],
+  "SORT_RO": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sorted elements."
+  ],
+  "SPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist.",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the removed member.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a aist of the removed members."
+  ],
+  "SPUBLISH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of clients that received the message. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count"
+  ],
+  "SRANDMEMBER": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or a [Null reply](/docs/reference/protocol-spec#nulls) when _key_ doesn't exist.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when the optional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist."
+  ],
+  "SREM": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): Number of members that were removed from the set, not including non existing members."
+  ],
+  "SSCAN": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, an array with two elements:",
+    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) with the names of scanned members."
+  ],
+  "SSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each shard channel, one message with the first element being the string 'ssubscribe' is pushed as a confirmation that the command succeeded. Note that this command can also return a -MOVED redirect."
+  ],
+  "STRLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string stored at key, or 0 when the key does not exist."
+  ],
+  "SUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each channel, one message with the first element being the string `subscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "SUBSTR": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+  ],
+  "SUNION": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list with the members of the resulting set."
+  ],
+  "SUNIONSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): Number of the elements in the resulting set."
+  ],
+  "SUNSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each shard channel, one message with the first element being the string `sunsubscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "SWAPDB": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "SYNC": [
+    "**Non-standard return value**, a bulk transfer of the data followed by `PING` and write requests from the master."
+  ],
+  "TIME": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, a two-element array consisting of the Unix timestamp in seconds and the microseconds' count."
+  ],
+  "TOUCH": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of touched keys."
+  ],
+  "TTL": [
+    "One of the following:",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): TTL in seconds.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+  ],
+  "TYPE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): the type of _key_, or `none` when _key_ doesn't exist."
+  ],
+  "UNLINK": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that were unlinked."
+  ],
+  "UNSUBSCRIBE": [
+    "When successful, this command doesn't return anything. Instead, for each channel, one message with the first element being the string `unsubscribe` is pushed as a confirmation that the command succeeded."
+  ],
+  "UNWATCH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "WAIT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of replicas reached by all the writes performed in the context of the current connection."
+  ],
+  "WAITAOF": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): The command returns an array of two integers:",
+    "1. The first is the number of local Redises (0 or 1) that have fsynced to AOF  all writes performed in the context of the current connection",
+    "2. The second is the number of replicas that have acknowledged doing the same."
+  ],
+  "WATCH": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "XACK": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged."
+  ],
+  "XADD": [
+    "One of the following:",
+    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the NOMKSTREAM option is given and the key doesn't exist."
+  ],
+  "XAUTOCLAIM": [
+    "[Array reply](/docs/reference/protocol-spec#arrays), specifically, an array with three elements:",
+    "1. A stream ID to be used as the _start_ argument for the next call to XAUTOCLAIM.",
+    "2. An [Array reply](/docs/reference/protocol-spec#arrays) containing all the successfully claimed messages in the same format as `XRANGE`.",
+    "3. An [Array reply](/docs/reference/protocol-spec#arrays) containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found."
+  ],
+  "XCLAIM": [
+    "Any of the following:",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): when the _JUSTID_ option is specified, an array of IDs of messages successfully claimed.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of stream entries, each of which contains an array of two elements, the entry ID and the entry data itself."
+  ],
+  "XDEL": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries that were deleted."
+  ],
+  "XGROUP": [],
+  "XGROUP CREATE": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "XGROUP CREATECONSUMER": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of created consumers, either 0 or 1."
+  ],
+  "XGROUP DELCONSUMER": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of pending messages the consumer had before it was deleted."
+  ],
+  "XGROUP DESTROY": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of destroyed consumer groups, either 0 or 1."
+  ],
+  "XGROUP HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "XGROUP SETID": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "XINFO": [],
+  "XINFO CONSUMERS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of consumers and their attributes."
+  ],
+  "XINFO GROUPS": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of consumer groups."
+  ],
+  "XINFO HELP": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+  ],
+  "XINFO STREAM": [
+    "One of the following:",
+    "* [Map reply](/docs/reference/protocol-spec#maps): when the _FULL_ argument was not given, a list of information about a stream in summary form.",
+    "* [Map reply](/docs/reference/protocol-spec#maps): when the _FULL_ argument was given, a list of information about a stream in extended form."
+  ],
+  "XLEN": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries of the stream at _key_."
+  ],
+  "XPENDING": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): different data depending on the way XPENDING is called, as explained on this page."
+  ],
+  "XRANGE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of stream entries with IDs matching the specified range."
+  ],
+  "XREAD": [
+    "One of the following:",
+    "* [Map reply](/docs/reference/protocol-spec#maps): A map of key-value elements where each element is composed of the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
+  ],
+  "XREADGROUP": [
+    "One of the following:",
+    "* [Map reply](/docs/reference/protocol-spec#maps): A map of key-value elements where each element is composed of the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
+  ],
+  "XREVRANGE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): The command returns the entries with IDs matching the specified range. The returned entries are complete, which means that the ID and all the fields they are composed of are returned. Moreover, the entries are returned with their fields and values in the same order as `XADD` added them."
+  ],
+  "XSETID": [
+    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+  ],
+  "XTRIM": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): The number of entries deleted from the stream."
+  ],
+  "ZADD": [
+    "Any of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new members when the _CH_ option is not used.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new or updated members when the _CH_ option is used.",
+    "* [Double reply](/docs/reference/protocol-spec#doubles): the updated score of the member when the _INCR_ option is used."
+  ],
+  "ZCARD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the cardinality (number of members) of the sorted set, or 0 if the key doesn't exist."
+  ],
+  "ZCOUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the specified score range."
+  ],
+  "ZDIFF": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the result of the difference including, optionally, scores when the _WITHSCORES_ option is used."
+  ],
+  "ZDIFFSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting sorted set at _destination_."
+  ],
+  "ZINCRBY": [
+    "[Double reply](/docs/reference/protocol-spec#doubles): the new score of _member_."
+  ],
+  "ZINTER": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the result of the intersection including, optionally, scores when the _WITHSCORES_ option is used."
+  ],
+  "ZINTERCARD": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting intersection."
+  ],
+  "ZINTERSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting sorted set at the _destination_."
+  ],
+  "ZLEXCOUNT": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the specified score range."
+  ],
+  "ZMPOP": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+  ],
+  "ZMSCORE": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the member does not exist in the sorted set.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of [Double reply](/docs/reference/protocol-spec#doubles) _member_ scores as double-precision floating point numbers."
+  ],
+  "ZPOPMAX": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of popped elements and scores."
+  ],
+  "ZPOPMIN": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of popped elements and scores."
+  ],
+  "ZRANDMEMBER": [
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or [Null reply](/docs/reference/protocol-spec#nulls) when _key_ doesn't exist.",
+    "[Array reply](/docs/reference/protocol-spec#arrays): when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
+  ],
+  "ZRANGE": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given."
+  ],
+  "ZRANGEBYLEX": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): a list of elements in the specified score range."
+  ],
+  "ZRANGEBYSCORE": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of the members with, optionally, their scores in the specified score range."
+  ],
+  "ZRANGESTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting sorted set."
+  ],
+  "ZRANK": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist or the member does not exist in the sorted set.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): the rank of the member when _WITHSCORES_ is not used.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): the rank and score of the member when _WITHSCORES_ is used."
+  ],
+  "ZREM": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed from the sorted set, not including non-existing members."
+  ],
+  "ZREMRANGEBYLEX": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): Number of members removed."
+  ],
+  "ZREMRANGEBYRANK": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): Number of members removed."
+  ],
+  "ZREMRANGEBYSCORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): Number of members removed."
+  ],
+  "ZREVRANGE": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified range, optionally with their scores if _WITHSCORE_ was used."
+  ],
+  "ZREVRANGEBYLEX": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): List of the elements in the specified score range."
+  ],
+  "ZREVRANGEBYSCORE": [
+    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of the members and, optionally, their scores in the specified score range."
+  ],
+  "ZREVRANK": [
+    "One of the following:",
+    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist or the member does not exist in the sorted set.",
+    "* [Integer reply](/docs/reference/protocol-spec#integers): The rank of the member when _WITHSCORE_ is not used.",
+    "* [Array reply](/docs/reference/protocol-spec#arrays): The rank and score of the member when _WITHSCORE_ is used."
+  ],
+  "ZSCAN": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): cursor and scan response in array form."
+  ],
+  "ZSCORE": [
+    "One of the following:",
+    "* [Double reply](/docs/reference/protocol-spec#doubles): the score of the member (a double-precision floating point number).",
+    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if _member_ does not exist in the sorted set, or the key does not exist."
+  ],
+  "ZUNION": [
+    "[Array reply](/docs/reference/protocol-spec#arrays): the result of the union with, optionally, their scores when _WITHSCORES_ is used."
+  ],
+  "ZUNIONSTORE": [
+    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting sorted set."
+  ]
+}


### PR DESCRIPTION
The following changes have been made for this PR:
- Added resp2_replies.json and resp3_replies.json. These files contain RESP reply information for all base commands.
- Edited each command's Markdown file to remove existing reply information. This will be added back in at site build time.
- Update the README.md file with new instructions regarding reply information.