### PR TITLE
Add an explanation for URI with -u in redis-cli

### DIFF
--- a/docs/connect/cli.md
+++ b/docs/connect/cli.md
@@ -122,6 +122,8 @@ option and the URI pattern `redis://user:password@host:port/dbnum`:
     $ redis-cli -u redis://LJenkins:p%40ssw0rd@redis-16379.hosted.com:16379/0 PING
     PONG
 
+**NOTE:** User, password and dbnum are optional. For authentication without a username, use username `default`. For TLS, use the scheme `rediss`.
+
 ## SSL/TLS
 
 By default, `redis-cli` uses a plain TCP connection to connect to Redis.

--- a/docs/connect/cli.md
+++ b/docs/connect/cli.md
@@ -122,7 +122,10 @@ option and the URI pattern `redis://user:password@host:port/dbnum`:
     $ redis-cli -u redis://LJenkins:p%40ssw0rd@redis-16379.hosted.com:16379/0 PING
     PONG
 
-**NOTE:** User, password and dbnum are optional. For authentication without a username, use username `default`. For TLS, use the scheme `rediss`.
+**NOTE:**
+User, password and dbnum are optional.
+For authentication without a username, use username `default`.
+For TLS, use the scheme `rediss`.
 
 ## SSL/TLS
 


### PR DESCRIPTION
It's good for users to know that they need to specify "default" as the username when authenticating without a username. Other details of the URI format are described too, like scheme and dbnum.

It used to be possible to connect to Redis using an URL with an empty username, like redis-cli -u redis://:PASSWORD@localhost:6379/0. This was broken in 6.2 (https://github.com/redis/redis/pull/8048), and there was a discussion about it https://github.com/redis/redis/issues/9186. 
Now, users need to specify "default" as the username and it's better to document it.

Refer to https://github.com/redis/redis/issues/12746 and #2523 for more details.