### PR TITLE
Revise the response description of `OBJECT FREQ` command

### DIFF
--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -767,7 +767,9 @@
     "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the encoding of the object."
   ],
   "OBJECT FREQ": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the counter's value."
+    "One of the following:",
+    "[Integer reply](/docs/reference/protocol-spec#integers): the counter's value.",
+    "[Nil reply](/docs/reference/protocol-spec#bulk-strings): if _key_ doesn't exist."
   ],
   "OBJECT HELP": [
     "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -767,7 +767,9 @@
     "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the encoding of the object."
   ],
   "OBJECT FREQ": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the counter's value."
+    "One of the following:",
+    "[Integer reply](/docs/reference/protocol-spec#integers): the counter's value.",
+    "[Null reply](/docs/reference/protocol-spec#nulls): if _key_ doesn't exist."
   ],
   "OBJECT HELP": [
     "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."


### PR DESCRIPTION
`OBJECT FREQ` would return the nil/null response if the target key doesn't exist.