### PR TITLE
Remove nil/null reply description from ZADD command

### DIFF
--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -1204,7 +1204,6 @@
   ],
   "ZADD": [
     "Any of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.",
     "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new members when the _CH_ option is not used.",
     "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new or updated members when the _CH_ option is used.",
     "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the updated score of the member when the _INCR_ option is used."

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -1269,7 +1269,6 @@
   ],
   "ZADD": [
     "Any of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.",
     "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new members when the _CH_ option is not used.",
     "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new or updated members when the _CH_ option is used.",
     "* [Double reply](/docs/reference/protocol-spec#doubles): the updated score of the member when the _INCR_ option is used."


### PR DESCRIPTION
This command doesn't return nil/null reply even if the NX/XX/LT/GT options are conflict; in that case, it returns the error reply like the following:

```
zadd z XX NX 1 foo
-ERR XX and NX options at the same time are not compatible
zadd z NX GT 1 foo
-ERR GT, LT, and/or NX options at the same time are not compatible
zadd z LT GT 1 foo
-ERR GT, LT, and/or NX options at the same time are not compatible
```