### PR TITLE
Update hincrbyfloat.md

### DIFF
--- a/commands/hincrbyfloat.md
+++ b/commands/hincrbyfloat.md
@@ -4,7 +4,7 @@ is negative, the result is to have the hash field value **decremented** instead 
 If the field does not exist, it is set to `0` before performing the operation.
 An error is returned if one of the following conditions occur:
 
-* The field contains a value of the wrong type (not a string).
+* The key contains a value of the wrong type (not a hash).
 * The current field content or the specified increment are not parsable as a
   double precision floating point number.
 


### PR DESCRIPTION
WRONGTYPE is about the key type, not the field type.
looks like a copy paste issue from INCRBYFLOAT