### PR TITLE
Fix incorrect output of example in ACL DRYRUN

### DIFF
--- a/commands/acl-dryrun.md
+++ b/commands/acl-dryrun.md
@@ -8,6 +8,6 @@ This command can be used to test the permissions of a given user without having 
 "OK"
 > ACL DRYRUN VIRGINIA SET foo bar
 "OK"
-> ACL DRYRUN VIRGINIA GET foo bar
-"This user has no permissions to run the 'GET' command"
+> ACL DRYRUN VIRGINIA GET foo
+"User VIRGINIA has no permissions to run the 'get' command"
 ```


### PR DESCRIPTION
In redis/redis#10405, we will check arity first, so the example
output is wrong. And in redis/redis#11160, we changed the text.
```
127.0.0.1:6379> ACL DRYRUN VIRGINIA GET foo bar
(error) ERR wrong number of arguments for 'get' command

127.0.0.1:6379> ACL DRYRUN VIRGINIA GET foo
"User VIRGINIA has no permissions to run the 'get' command"
```