### PR TITLE
Add redis-delay-queue to the community modules list

### DIFF
--- a/modules/community/github.com/if-nil/redis-delay-queue.json
+++ b/modules/community/github.com/if-nil/redis-delay-queue.json
@@ -1,0 +1,8 @@
+{
+    "name": "redis-delay-queue",
+    "license": "MIT",
+    "description": "A redis module for delay queue.",
+    "github": [
+        "if-nil"
+    ]
+}


### PR DESCRIPTION
Adding [redis-delay-queue](https://github.com/if-nil/redis-delay-queue) module to the list.