### PR TITLE
Update keys.bytes-per-key's description.

### DIFF
--- a/commands/memory-stats.md
+++ b/commands/memory-stats.md
@@ -29,8 +29,7 @@ values. The following metrics are reported:
      Redis keyspace (see `INFO`'s `used_memory_overhead`)
 *   `keys.count`: The total number of keys stored across all databases in the
      server
-*   `keys.bytes-per-key`: The ratio between **net memory usage** (`total.allocated`
-     minus `startup.allocated`) and `keys.count` 
+*   `keys.bytes-per-key`: The ratio between `dataset.bytes` and `keys.count` 
 *   `dataset.bytes`: The size in bytes of the dataset, i.e. `overhead.total`
      subtracted from `total.allocated` (see `INFO`'s `used_memory_dataset`)
 *   `dataset.percentage`: The percentage of `dataset.bytes` out of the total


### PR DESCRIPTION
see redis/redis#12897, the computing method has changed for bytes-per-key.