### PR TITLE
Fix outdated incorrect example in function delete

### DIFF
--- a/commands/function-delete.md
+++ b/commands/function-delete.md
@@ -8,8 +8,8 @@ For more information please refer to [Introduction to Redis Functions](/topics/f
 @examples
 
 ```
-redis> FUNCTION LOAD Lua mylib "redis.register_function('myfunc', function(keys, args) return 'hello' end)"
-OK
+redis> FUNCTION LOAD "#!lua name=mylib \n redis.register_function('myfunc', function(keys, args) return 'hello' end)"
+"mylib"
 redis> FCALL myfunc 0
 "hello"
 redis> FUNCTION DELETE mylib


### PR DESCRIPTION
The command format is using the old one and it is outdated.