### PR TITLE
Add Redis::Cluster::Fast client

### DIFF
--- a/clients/perl/github.com/plainbanana/Redis-Cluster-Fast.json
+++ b/clients/perl/github.com/plainbanana/Redis-Cluster-Fast.json
@@ -1,0 +1,8 @@
+{
+  "name": "Redis::Cluster::Fast",
+  "description": "A fast Perl binding for Redis Cluster",
+  "homepage": "http://search.cpan.org/dist/Redis-Cluster-Fast/",
+  "twitter": [
+    "plainbanana"
+  ]
+}


### PR DESCRIPTION
[Redis::Cluster::Fast](https://github.com/plainbanana/Redis-Cluster-Fast) is a Perl XS module to connect Redis Cluster by hiredis-cluster and hiredis.

Implementing and maintaining a Redis Cluster client correctly, especially with error handling, is quite complex and difficult.  By leveraging the async cluster context of hiredis-cluster, it allows us to update the cluster topology as needed while processing commands. 