### PR TITLE
Add Lua os library section

### DIFF
--- a/docs/interact/programmability/lua-api.md
+++ b/docs/interact/programmability/lua-api.md
@@ -670,6 +670,9 @@ The following [standard Lua libraries](https://www.lua.org/manual/5.1/manual.htm
 * The [_String Manipulation (string)_ library](https://www.lua.org/manual/5.1/manual.html#5.4)
 * The [_Table Manipulation (table)_ library](https://www.lua.org/manual/5.1/manual.html#5.5)
 * The [_Mathematical Functions (math)_ library](https://www.lua.org/manual/5.1/manual.html#5.6)
+* The [_Operating System Facilities (os)_ library](https://www.lua.org/manual/5.1/manual.html#5.8)
+  Note that for sandbox security, currently only the following os API is exposed:
+  * `os.clock()`
 
 In addition, the following external libraries are loaded and accessible to scripts:
 


### PR DESCRIPTION
in https://github.com/redis/redis/pull/12971 we expose a new Lua os api `os.clock()`.