### PR TITLE
Fix the rendering of the RESP documentation for the INFO command

### DIFF
--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -601,9 +601,9 @@
     "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key after the increment."
   ],
   "INFO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a map of info fields, one field per line in the form of <field>:<value> where the value can be a comma separated map like <key>=<val>. Also contains section header lines starting with `#` and blank lines.",
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines.",
     "",
-    "Lines can contain a section name (starting with a # character) or a property. All the properties are in the form of `field:value` terminated by `\r\n`."
+    "Lines can contain a section name (starting with a `#` character) or a property. All the properties are in the form of `field:value` terminated by `\\r\\n`."
   ],
   "KEYS": [
     "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys matching _pattern_."

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -601,9 +601,9 @@
     "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key after the increment."
   ],
   "INFO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a map of info fields, one field per line in the form of <field>:<value> where the value can be a comma separated map like <key>=<val>. Also contains section header lines starting with `#` and blank lines.",
+    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines.",
     "",
-    "Lines can contain a section name (starting with a # character) or a property. All the properties are in the form of `field:value` terminated by `\r\n`."
+    "Lines can contain a section name (starting with a `#` character) or a property. All the properties are in the form of `field:value` terminated by `\\r\\n`."
   ],
   "KEYS": [
     "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys matching _pattern_."


### PR DESCRIPTION
On https://redis.io/commands/info/ at the bottom, the RESP documentation renders like this:
<img width="504" alt="image" src="https://github.com/redis/redis-doc/assets/2158944/616d6426-79c9-4eb8-b8fc-b8a301461ec3">
Notice the
>in the form of : where

and
>separated map like =.

and
>terminated by .