### PR TITLE
Add server start instruction

### DIFF
--- a/docs/install/install-redis/install-redis-on-linux.md
+++ b/docs/install/install-redis/install-redis-on-linux.md
@@ -33,6 +33,12 @@ sudo apt-get update
 sudo apt-get install redis
 {{< / highlight  >}}
 
+Lastly, start the Redis server like so:
+
+{{< highlight bash  >}}
+sudo service redis-server start
+{{< / highlight  >}}
+
 ## Install from Snapcraft
 
 The [Snapcraft store](https://snapcraft.io/store) provides [Redis packages](https://snapcraft.io/redis) that can be installed on platforms that support snap.


### PR DESCRIPTION
After initial installation server was up and running.
But after restarting computer (or something, not sure) could not connect:
```
$ redis-cli 
Could not connect to Redis at 127.0.0.1:6379: Connection refused
not connected>
```
Spent some time understanding how I started it initially.
Having found answer on `askubuntu.com`, googled if Redis docs have this instruction (`site:redis.io "service redis-server" start`)
Found it on [Windows](https://redis.io/docs/install/install-redis/install-redis-on-windows/) page