### PR TITLE
DOC-3564: fix Java client menu

### DIFF
--- a/docs/connect/clients/java/_index.md
+++ b/docs/connect/clients/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Connect with Redis Java clients"
-linkTitle: "Java clients"
+linkTitle: "Java"
 description: Connect your application to a Redis database using Java and try an example
 weight: 3
 ---

--- a/docs/connect/clients/java/jedis.md
+++ b/docs/connect/clients/java/jedis.md
@@ -1,6 +1,6 @@
 ---
-title: "Java guide"
-linkTitle: "Java"
+title: "Jedis guide"
+linkTitle: "Jedis"
 description: Connect your Java application to a Redis database
 weight: 1
 aliases:


### PR DESCRIPTION
This PR corrects the Connect > Clients > Java section.

@dmaier-redislabs or @mich-elle-luna Please review ASAP so I can get it merged.