### PR TITLE
Update distributed-locks.md: add new Ruby Implementation

### DIFF
--- a/docs/manual/patterns/distributed-locks.md
+++ b/docs/manual/patterns/distributed-locks.md
@@ -32,6 +32,7 @@ Before describing the algorithm, here are a few links to implementations
 already available that can be used for reference.
 
 * [Redlock-rb](https://github.com/antirez/redlock-rb) (Ruby implementation). There is also a [fork of Redlock-rb](https://github.com/leandromoreira/redlock-rb) that adds a gem for easy distribution.
+* [RedisQueuedLocks](https://github.com/0exp/redis_queued_locks) (Ruby implementation)
 * [Redlock-py](https://github.com/SPSCommerce/redlock-py) (Python implementation).
 * [Pottery](https://github.com/brainix/pottery#redlock) (Python implementation).
 * [Aioredlock](https://github.com/joanvila/aioredlock) (Asyncio Python implementation).


### PR DESCRIPTION
Update distributed-locks.md: add new Ruby Implementation `redis_queued_locks`

Added new ruby implementation of Redis Distributed Locks `redis_queued_locks` to the **Implementations** list. 

The new implementation realizes "lock queues" feature.

https://github.com/0exp/redis_queued_locks