### PR TITLE
Add doc for Hash Field Expiration

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -266,6 +266,7 @@ Here is the meaning of all fields in the **stats** section:
 *   `sync_full`: The number of full resyncs with replicas
 *   `sync_partial_ok`: The number of accepted partial resync requests
 *   `sync_partial_err`: The number of denied partial resync requests
+*   `expired_hash_fields`: The number of hash fields expiration events
 *   `expired_keys`: Total number of key expiration events
 *   `expired_stale_perc`: The percentage of keys probably expired
 *   `expired_time_cap_reached_count`: The count of times that active expiry cycles have stopped early
@@ -444,7 +445,7 @@ The statistics are the number of keys, and the number of keys with an expiration
 
 For each database, the following line is added:
 
-*   `dbXXX`: `keys=XXX,expires=XXX`
+*   `dbXXX`: `keys=XXX,expires=XXX,avg_ttl=XXX,hashes_with_expiry_fields=XXX`
 
 The **debug** section contains experimental metrics, which might change or get removed in future versions.
 It won't be included when `INFO` or `INFO ALL` are called, and it is returned only when `INFO DEBUG` is used.

--- a/docs/manual/keyspace-notifications.md
+++ b/docs/manual/keyspace-notifications.md
@@ -116,6 +116,8 @@ Different commands generate different kind of events according to the following 
 * `HINCRBY` generates an `hincrby` event.
 * `HINCRBYFLOAT` generates an `hincrbyfloat` event.
 * `HDEL` generates a single `hdel` event, and an additional `del` event if the resulting hash is empty and the key is removed.
+* `HEXPIRE`, `HEXPIREAT`, `HPEXPIRE`, `HPEXPIREAT` commands all generate `hexpire` events.
+* `HPERSIST` generates a single `hpersist` events.
 * `SADD` generates a single `sadd` event, even in the variadic case.
 * `SREM` generates a single `srem` event, and an additional `del` event if the resulting set is empty and the key is removed.
 * `SMOVE` generates an `srem` event for the source key, and an `sadd` event for the destination key.


### PR DESCRIPTION
see https://github.com/redis/redis/pull/13303
1. Add a new field `expired_hash_fields` for `INFO STATS`.
2. Add a new field `hashes_with_expiry_fields` for `INFO KEYSPACE`.
3. Add two new notification events `hexpire` and `hpersist`.